### PR TITLE
DataPrepHook default

### DIFF
--- a/edflow/hooks/pytorch_hooks.py
+++ b/edflow/hooks/pytorch_hooks.py
@@ -1,7 +1,9 @@
-import torch
 import os
-import numpy as np
+import signal
+import sys
 
+import torch
+import numpy as np
 from tensorboardX import SummaryWriter
 
 from edflow.hooks.hook import Hook
@@ -9,10 +11,6 @@ from edflow.custom_logging import get_logger
 from edflow.util import retrieve
 from edflow.util import walk
 from edflow.iterators.batches import plot_batch
-
-import signal
-import sys
-
 
 """PyTorch hooks useful during training."""
 
@@ -205,10 +203,10 @@ class DataPrepHook(ToFromTorchHook):
     def before_step(self, step, fetches, feeds, batch):
         """
         Steps taken before the training step.
-        :param step:
-        :param fetches:
-        :param feeds:
-        :param batch:
+        :param step: Training step.
+        :param fetches: Fetches for the next session.run call.
+        :param feeds: Feeds for the next session.run call.
+        :param batch: The batch to be iterated over.
         :return:
         """
         def to_image(obj):
@@ -227,8 +225,8 @@ class DataPrepHook(ToFromTorchHook):
     def after_step(self, step, results):
         """
         Steps taken after the training step.
-        :param step:
-        :param results:
+        :param step: Training step.
+        :param results: Result of the session.
         :return:
         """
         super().after_step(step, results)

--- a/edflow/iterators/model_iterator.py
+++ b/edflow/iterators/model_iterator.py
@@ -179,8 +179,7 @@ class PyHookedModelIterator(object):
                  hooks=[],
                  bar_position=0,
                  nogpu=False,
-                 desc='',
-                 transform=True):
+                 desc=''):
         '''Constructor.
 
         Args:
@@ -201,10 +200,6 @@ class PyHookedModelIterator(object):
         self.num_epochs = num_epochs
 
         self.hooks = hooks
-        # check if the data preparation hook is already supplied.
-        check = transform and not any([isinstance(hook, DataPrepHook) for hook in self.hooks])
-        if check:
-            self.hooks += [DataPrepHook()]
 
         self.hook_freq = hook_freq
 
@@ -406,3 +401,12 @@ class TFHookedModelIterator(PyHookedModelIterator):
             sess_config.gpu_options.per_process_gpu_memory_fraction = gpu_mem_fraction
         self._session = tf.Session(config=sess_config)
         return self._session
+
+
+class TorchHookedModelIterator(PyHookedModelIterator):
+    def __init__(self, *args, transform=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        # check if the data preparation hook is already supplied.
+        check = transform and not any([isinstance(hook, DataPrepHook) for hook in self.hooks])
+        if check:
+            self.hooks += [DataPrepHook()]

--- a/edflow/iterators/model_iterator.py
+++ b/edflow/iterators/model_iterator.py
@@ -3,6 +3,7 @@ from tqdm import tqdm, trange
 
 from edflow.custom_logging import get_logger
 from edflow.util import walk
+from edflow.hooks.pytorch_hooks import DataPrepHook
 
 
 class HookedModelIterator(object):
@@ -178,7 +179,8 @@ class PyHookedModelIterator(object):
                  hooks=[],
                  bar_position=0,
                  nogpu=False,
-                 desc=''):
+                 desc='',
+                 transform=True):
         '''Constructor.
 
         Args:
@@ -189,6 +191,8 @@ class PyHookedModelIterator(object):
             hook_freq (int): Frequency at which hooks are evaluated.
             bar_position (int): Used by tqdm to place bars at the right
                 position when using multiple Iterators in parallel.
+            transform (bool): If the batches are to be transformed to pytorch tensors. Should be true even if your input
+                is already pytorch tensors!
         '''
         self.config = config
         self.root = root
@@ -197,6 +201,11 @@ class PyHookedModelIterator(object):
         self.num_epochs = num_epochs
 
         self.hooks = hooks
+        # check if the data preparation hook is already supplied.
+        check = transform and not any([isinstance(hook, DataPrepHook) for hook in self.hooks])
+        if check:
+            self.hooks += [DataPrepHook()]
+
         self.hook_freq = hook_freq
 
         self.bar_pos = bar_position * 2

--- a/edflow/iterators/model_iterator.py
+++ b/edflow/iterators/model_iterator.py
@@ -190,8 +190,6 @@ class PyHookedModelIterator(object):
             hook_freq (int): Frequency at which hooks are evaluated.
             bar_position (int): Used by tqdm to place bars at the right
                 position when using multiple Iterators in parallel.
-            transform (bool): If the batches are to be transformed to pytorch tensors. Should be true even if your input
-                is already pytorch tensors!
         '''
         self.config = config
         self.root = root
@@ -404,6 +402,12 @@ class TFHookedModelIterator(PyHookedModelIterator):
 
 
 class TorchHookedModelIterator(PyHookedModelIterator):
+    """
+    Iterator class for framework PyTorch, inherited from PyHookedModelIterator.
+    Args:
+        transform (bool): If the batches are to be transformed to pytorch tensors. Should be true even if your input
+                    is already pytorch tensors!
+    """
     def __init__(self, *args, transform=True, **kwargs):
         super().__init__(*args, **kwargs)
         # check if the data preparation hook is already supplied.

--- a/examples/mnist_pytorch/model.py
+++ b/examples/mnist_pytorch/model.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from edflow.iterators.model_iterator import PyHookedModelIterator
+from edflow.iterators.model_iterator import TorchHookedModelIterator
 
 
 class CNN(nn.Module):
@@ -30,7 +30,7 @@ class CNN(nn.Module):
         return F.log_softmax(x, dim=1)
 
 
-class Iterator(PyHookedModelIterator):
+class Iterator(TorchHookedModelIterator):
     def __init__(self, config, root, model, **kwargs):
         """
         THe iterator class is the backbone of your EDflow training. It will handle your training

--- a/examples/mnist_pytorch/model.py
+++ b/examples/mnist_pytorch/model.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from edflow.iterators.model_iterator import PyHookedModelIterator
-from edflow.hooks.pytorch_hooks import DataPrepHook
 
 
 class CNN(nn.Module):
@@ -55,8 +54,6 @@ class Iterator(PyHookedModelIterator):
                                           lr=lr,
                                           betas=(0.5, 0.9))
         self.criterion = torch.nn.CrossEntropyLoss()
-        DPrepH = DataPrepHook()
-        self.hooks += [DPrepH]
 
     def initialize(self, checkpoint=None, **kwargs):
         if checkpoint is not None:


### PR DESCRIPTION
DataPrepHook for PyTorch iterators, in charge conversion and transposing input arrays to PyTorch tensors and back, is included by default. Thus the example is also changed.