### PR TITLE
Test fix

### DIFF
--- a/tests/test_edflow.py
+++ b/tests/test_edflow.py
@@ -70,6 +70,7 @@ def run_edflow_cmdline(command, cwd):
         timeout=60,
     )
 
+
 class Test_eval(object):
     def setup_tmpdir(self, tmpdir):
         subdirs = ["code", "train", "eval", "ablation"]
@@ -87,9 +88,8 @@ class Test_eval(object):
     def make_dummy_checkpoint(self, checkpoint_path):
         with open(checkpoint_path, "w"):
             pass
-        with open('.'.join([checkpoint_path, "index"]), "w"):
+        with open(".".join([checkpoint_path, "index"]), "w"):
             pass
-
 
     def test_1(self, tmpdir):
         """

--- a/tests/test_edflow.py
+++ b/tests/test_edflow.py
@@ -31,7 +31,7 @@ class Iterator2(TFBaseEvaluator):
         """ iterator for testing that the provided checkpoint is None """
 
     def initialize(self, checkpoint_path=None):
-        assert checkpoint_path == None
+        assert checkpoint_path is None
 
     def iterate(self, batch_iterator):
         return None
@@ -70,7 +70,6 @@ def run_edflow_cmdline(command, cwd):
         timeout=60,
     )
 
-
 class Test_eval(object):
     def setup_tmpdir(self, tmpdir):
         subdirs = ["code", "train", "eval", "ablation"]
@@ -88,6 +87,9 @@ class Test_eval(object):
     def make_dummy_checkpoint(self, checkpoint_path):
         with open(checkpoint_path, "w"):
             pass
+        with open('.'.join([checkpoint_path, "index"]), "w"):
+            pass
+
 
     def test_1(self, tmpdir):
         """


### PR DESCRIPTION
The cli-test included a wrong test result because the dummy project was missing the ckpt.index files.

This PR will make the tests fail because we have a conflicting behavior with the tests