### PR TITLE
path based commandline

### DIFF
--- a/edflow/config/__init__.py
+++ b/edflow/config/__init__.py
@@ -1,1 +1,1 @@
-from edflow.config.commandline_kwargs import parse_unknown_args
+from edflow.config.commandline_kwargs import parse_unknown_args, update_config

--- a/edflow/config/commandline_kwargs.py
+++ b/edflow/config/commandline_kwargs.py
@@ -1,4 +1,22 @@
 import ast
+from edflow.util import set_value, walk, retrieve
+
+
+def update_config(config, additional_kwargs):
+    """additional_kwargs are added in order of the keys' length, e.g. 'a'
+    is overriden by 'a/b'."""
+    keys = sorted(additional_kwargs.keys())
+    for k in keys:
+        set_value(config, k, additional_kwargs[k])
+
+    def replace(k):
+        if isinstance(k, str) and k[0] == "{" and k[-1] == "}":
+            k_ = k[1:-1].strip()
+            return retrieve(config, k_, default=k)
+        else:
+            return k
+
+    walk(config, replace, inplace=True)
 
 
 def parse_unknown_args(unknown):

--- a/edflow/edflow
+++ b/edflow/edflow
@@ -24,15 +24,7 @@ from edflow.main import train, test  # noqa
 from edflow.custom_logging import init_project, use_project, get_logger  # noqa
 from edflow.custom_logging import set_global_stdout_level  # noqa
 from edflow.hooks.checkpoint_hooks.common import get_latest_checkpoint  # noqa
-from edflow.config import parse_unknown_args
-
-
-def update_config(config, additional_kwargs):
-    config.update(additional_kwargs)
-    # single format substitution, does not support nested structures
-    for k, v in config.items():
-        if isinstance(v, str):
-            config[k] = v.format(**config)
+from edflow.config import parse_unknown_args, update_config
 
 
 def main(opt, additional_kwargs):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,112 @@
+import pytest
+
+from edflow.config import parse_unknown_args, update_config
+
+
+def test_basic_parsing():
+    import argparse
+
+    A = argparse.ArgumentParser()
+
+    A.add_argument("--a", default="a", type=str)
+
+    passed = [
+        "--a",
+        "c",
+        "--b",
+        "b",
+        "--c",
+        "12.5",
+        "--d",
+        "True",
+        "--e",
+        "[14, 15]",
+        "--f",
+        "a.b.c",
+        "--g",
+        "a/b/c",
+        "--i",
+        "1",
+        "-j",
+        "2",
+        "-k",
+        "3.",
+        "-l",
+        "abc",
+        "-m",
+        "{'asd': 3.5}",
+        "--abc/def",
+        "1.0",
+        "--abc/def/ghi",
+        "2.0",
+        "--abc/jkl",
+        "3.0",
+        "--xyz/0",
+        "4.0",
+    ]
+
+    print(passed)
+    args, unknown = A.parse_known_args(passed)
+
+    unknown = parse_unknown_args(unknown)
+
+    assert not "a" in unknown
+    ref = {
+        "b": "b",
+        "c": 12.5,
+        "d": True,
+        "e": [14, 15],
+        "f": "a.b.c",
+        "g": "a/b/c",
+        "i": 1,
+        "j": 2,
+        "k": 3.0,
+        "l": "abc",
+        "m": {"asd": 3.5},
+        "abc/def": 1.0,
+        "abc/def/ghi": 2.0,
+        "abc/jkl": 3.0,
+        "xyz/0": 4.0,
+    }
+    assert ref == unknown
+
+
+def test_update_config():
+    config = dict()
+    updates = {"a/b": 1.0, "a": 2}
+    update_config(config, updates)
+    ref = {"a": {"b": 1.0}}
+    assert config == ref
+
+    config = {"a": {"x": 0}}
+    updates = {"a/y": 1}
+    update_config(config, updates)
+    ref = {"a": {"x": 0, "y": 1}}
+    assert config == ref
+
+    config = {"a": {"x": 0}}
+    updates = {"a/x": 1}
+    update_config(config, updates)
+    ref = {"a": {"x": 1}}
+    assert config == ref
+
+    config = {"a": {"x": 0}}
+    updates = {"a/0": 1}
+    update_config(config, updates)
+    ref = {"a": {"x": 0, 0: 1}}
+    assert config == ref
+
+    config = {"a": {"x": 0}}
+    updates = {"a/x/1": 1}
+    update_config(config, updates)
+    ref = {"a": {"x": [None, 1]}}
+    assert config == ref
+
+
+def test_config_format():
+    config = dict()
+    updates = {"a/b": 1.0, "x": "{a/b}"}
+    update_config(config, updates)
+    print(config)
+    ref = {"a": {"b": 1.0}, "x": 1.0}
+    assert config == ref


### PR DESCRIPTION
:tada: :white_check_mark: 
path based commandline arguments and substitution plus tests.
you can now add parameters to nested config objects with `--path/to/config/object 'value'` and values in the config yaml file or values on the commandline can be a format string (string starting with `{` and ending with `}`) which will be substitued based on its path, i.e. `--otherkey '{path/to/config/object}'` in combination with the previous cmdline arg becomes `{"path": {"to": {"config": {"object": "value"}}}, "otherkey": "value"}`