### PR TITLE
Fix retrieve

### DIFF
--- a/edflow/util.py
+++ b/edflow/util.py
@@ -136,7 +136,7 @@ def walk(dict_or_list, fn, inplace=False, pass_key=False, prev_key=""):  # noqa
 
 class KeyNotFoundError(Exception):
     def __init__(self, cause):
-        self.cause = casue
+        self.cause = cause
 
 
 def retrieve(

--- a/edflow/util.py
+++ b/edflow/util.py
@@ -183,9 +183,11 @@ def retrieve(
         for key in keys:
             if callable(list_or_dict):
                 if not expand:
-                    raise KeyNotFoundError(ValueError(
-                        "Trying to get past callable node with expand=False."
-                        ))
+                    raise KeyNotFoundError(
+                        ValueError(
+                            "Trying to get past callable node with expand=False."
+                        )
+                    )
                 list_or_dict = list_or_dict()
                 parent[last_key] = list_or_dict
             last_key = key

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -489,6 +489,30 @@ def test_retrieve_pass_success_fail_ef_callable():
         val = retrieve(dol, "b/c/d", pass_success=True, expand=False)
 
 
+def failing_leave():
+    raise Exception()
+    return {"c": nested_leave}
+
+
+class CustomException(Exception):
+    pass
+
+
+def custom_leave():
+    raise CustomException()
+    return {"c": nested_leave}
+
+
+def test_retrieve_propagates_exception():
+    dol = {"a": [1, 2], "b": failing_leave, "e": 2}
+    with pytest.raises(Exception):
+        val = retrieve(dol, "b/c/d", default=0)
+
+    dol = {"a": [1, 2], "b": custom_leave, "e": 2}
+    with pytest.raises(CustomException):
+        val = retrieve(dol, "b/c/d", default=0)
+
+
 # ====================== walk ====================
 
 


### PR DESCRIPTION
retrieve catched all exceptions to handle missing keys. this suppressed exceptions thrown in callables that are expanded during retrieving