### PR TITLE
Pipy conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,11 +66,3 @@ jobs:
       script:
         - cd examples
         - python -m pytest -k torch
-
-deploy:
-  provider: pypi
-  user: "jhaux"
-  password:
-    secure: "yCTYOAbzCFK6aeKQSn2Q4XW5DN5/Gy0/4NmbFF4y07HcqBw2A7XOF7eQcsgNMSiMLu3IrY8iNuZL1urVn7k/m3V5xdQXcYtNJN1ZDcmKKOZHCp+uZoHTw6VzsNA8LhTXJbE9K1rLlfvzPEzoG/YedXpe7KGN7seMk+/w5dBUqzs30appqX395fQ7yfvsRd7h0B67HhtaGAlmumtqwqwRsMLgjGFxT0nW8lduziDfc0UhtvA3XX+Jbl5R8zXlEYg+44nqr2SyFEQN8am0Ig+mb1qkdoH7/QkB96tXMJkjxdKOmqm31uaHXP7AJ5ptTtHghZteiFxxzhQtVl7FH4GFJSwRhlybYbdSaNiNN8DDyW8cWxibDBnljg434o8jDk0npou5o4bsUQp/BiBELrRkEZiUk/pbph6N/WAIAW7GR3p2r2uxbINjr0iWnY8/VzajTgdGgsONAnnPMXlCYJYcK/cOphZzQu/Gm8lYVPRts9IbRW2kSfiWXCejct74nK7vmyFnN5LNK5C/QFVjBMJCOxmhf0Mv6zpI42o3/Xn7qdPkU6mEjPLVF8NeuYYi8HIb5Gk44zzoblnfPN8QZgjYRwYlMKMhKofzPZ02G2eOv5fO63fKfzFnEQWkndJKuVJ0+nKkRWMvjfcIHS3Upp9iTsXxirUva+Amz/bHbbcSTAI="
-  on:
-    tags: true

--- a/release.sh
+++ b/release.sh
@@ -1,2 +1,0 @@
-python3 setup.py sdist bdist_wheel
-twine upload dist/*

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,68 @@
+# Releasing edflow
+
+When releasing to `pipy` and `conda` simply run the `release.sh` script. For this to succeed you need to know Johannes' login credentials.
+
+You can do this all by hand as well. Always publish to `pipy` first and then to `conda`.
+
+## pipy
+> see also `release2pypi.sh`
+
+Install the following:
+```
+pip install twine
+# or
+conda install -c conda-forge twine
+```
+
+Then run the following:
+```
+python setup.py sdist bdist_wheel
+twine upload --skip-existing dist/*
+```
+
+This will push to pypi.
+
+## conda
+> see also `release2conda.sh`
+
+Install the following packages:
+```
+conda install conda-build
+conda install anaconda-client
+```
+
+Now run the following commands:
+```
+VERSION=$(python ../setup.py --version)
+
+conda skeleton pypi edflow --version $VERSION
+
+# the opencv package changed its name
+# This is a hack which should be fixed at some point
+sed -i 's/opencv-python/opencv/g' edflow/meta.yaml
+
+# Build for python 3.6 and 3.7
+conda-build -c conda-forge --python 3.6 edflow
+conda-build -c conda-forge --python 3.7 edflow
+
+# Convert the package for all relevant platforms.
+# Get the <path/to/XX-package> from the conda-build output
+conda convert -f --platform all <path/to/3.6-package>.tar.bz2 -o outputdir/
+conda convert -f --platform all <path/to/3.7-package>.tar.bz2 -o outputdir/
+
+
+# Now push to anaconda
+
+anaconda login
+
+for folder in $(ls outputdir); do
+        for file in $(ls outputdir/"$folder"); do
+                anaconda upload outputdir/$folder/$file
+        done
+done
+# Need to also upload the not converted files!
+anaconda upload <path/to/3.6-package>.tar.bz2
+anaconda upload <path/to/3.7-package>.tar.bz2
+
+anaconda logout
+```

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,2 +1,3 @@
 bash release2pypi.sh
-bash release2conda.sh $(python setup.py --version)
+# This does not yet work anywhere!
+# bash release2conda.sh $(python setup.py --version)

--- a/release/release.sh
+++ b/release/release.sh
@@ -1,0 +1,2 @@
+bash release2pypi.sh
+bash release2conda.sh $(python setup.py --version)

--- a/release/release2conda.sh
+++ b/release/release2conda.sh
@@ -22,8 +22,8 @@ sed -i 's/opencv-python/opencv/g' edflow/meta.yaml
 conda-build -c conda-forge --python 3.6 edflow
 conda-build -c conda-forge --python 3.7 edflow
 
-# conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py36h39e3cac_0.tar.bz2 -o outputdir/
-conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py37h39e3cac_0.tar.bz2 -o outputdir/
+conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-$VERSION-py36h39e3cac_0.tar.bz2 -o outputdir/
+conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-$VERSION-py37h39e3cac_0.tar.bz2 -o outputdir/
 
 # To upload you need the anaconda client
 # conda install anaconda-client
@@ -35,7 +35,7 @@ for folder in $(ls outputdir); do
         done
 done
 # Need to also upload the not converted files!
-anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py36h39e3cac_0.tar.bz2
-anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py37h39e3cac_0.tar.bz2
+anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-$VERSION-py36h39e3cac_0.tar.bz2
+anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-$VERSION-py37h39e3cac_0.tar.bz2
 
 anaconda logout

--- a/release/release2conda.sh
+++ b/release/release2conda.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script executes all the commands to publish edflow to anaconda.
+# After running it, you can install edflow using
+#
+# >>> conda install -c conda-forge -c jhaux edflow
+#
+# It is recommended to first publish to pypi and then run this script, as it
+# pulls the specified version from pypi.
+
+# Get the version of the package from the commandline arguments
+VERSION=$1
+
+# Full docu of what is happening can be found here:
+# https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html
+
+# If you need conda-build -> This is how you get it
+# conda install conda-build
+
+conda skeleton pypi edflow --version $VERSION
+sed -i 's/opencv-python/opencv/g' edflow/meta.yaml
+conda-build -c conda-forge --python 3.6 edflow
+conda-build -c conda-forge --python 3.7 edflow
+
+# conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py36h39e3cac_0.tar.bz2 -o outputdir/
+conda convert -f --platform all /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py37h39e3cac_0.tar.bz2 -o outputdir/
+
+# To upload you need the anaconda client
+# conda install anaconda-client
+anaconda login
+
+for folder in $(ls outputdir); do
+        for file in $(ls outputdir/"$folder"); do
+                anaconda upload outputdir/$folder/$file
+        done
+done
+# Need to also upload the not converted files!
+anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py36h39e3cac_0.tar.bz2
+anaconda upload /home/jhaux/miniconda3/envs/edbase/conda-bld/linux-64/edflow-0.2-py37h39e3cac_0.tar.bz2
+
+anaconda logout

--- a/release/release2pypi.sh
+++ b/release/release2pypi.sh
@@ -1,0 +1,2 @@
+python3 setup.py sdist bdist_wheel
+twine upload --skip-existing dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,13 @@
 from setuptools import setup, find_packages
 
+
+# allows to get version via python setup.py --version
+__version__ = "0.2.1"
+
+
 setup(
     name="edflow",
-    version="0.2",
+    version=__version__,
     description="Logistics for Deep Learning",
     url="https://github.com/pesser/edflow",
     author="Mimo Tilbich et al.",


### PR DESCRIPTION
Here I add some functionality and a README how to release to pypi and conda. Please take a look at the `release/README.md`.

I have not yet found a solution to automate all the conda specific stuff, but my guess is, we do not really need this and just release from time to time by hand.

If you want you can also try to
```
conda install -c conda-forge -c jhaux edflow
```
We need the `conda-forge` channel for the `deprecated` dependency.