### PR TITLE
Fixexc

### DIFF
--- a/edflow/edflow
+++ b/edflow/edflow
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import signal
 
 import sys  # noqa
 
@@ -168,10 +169,14 @@ def main(opt, additional_kwargs):
         )
         processes.append(test_process)
 
+    code = 0
     # Take off
     try:
+        # children should ignore sigint; we'll send SIGTERM upon SIGINT
+        sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         for p in processes:
             p.start()
+        signal.signal(signal.SIGINT, sigint_handler)
         logger.info("Started {} process(es).".format(len(processes)))
 
         done_count = 0
@@ -195,15 +200,18 @@ def main(opt, additional_kwargs):
         for p in processes:
             p.terminate()
         if not isinstance(e, KeyboardInterrupt):
-            # reraise if we caught a general exception
-            # TODO: only reraise if this is not an exception of a child that
+            code = 1
+            # only reraise if this is not an exception of a child that
             # was already logged above
-            raise e
+            if not e == exc_or_done:
+                raise e
     finally:
         # Landing
         for p in processes:
             p.join()
         logger.info("Finished")
+
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/edflow/iterators/batches.py
+++ b/edflow/iterators/batches.py
@@ -113,13 +113,13 @@ class Iterator(MultiprocessIterator):
         return math.ceil(self.n / self.batch_size)
 
 
-def make_batches(dataset, batch_size, shuffle, n_processes=8, n_prefetch=1, error_on_timeout=False):
+def make_batches(
+    dataset, batch_size, shuffle, n_processes=8, n_prefetch=1, error_on_timeout=False
+):
     # the first n_processes / batch_size batches will be quite slow for some
     # reason
     if error_on_timeout:
-        warnings.simplefilter(
-                'error',
-                MultiprocessIterator.TimeoutWarning)
+        warnings.simplefilter("error", MultiprocessIterator.TimeoutWarning)
     batches = Iterator(
         dataset,
         repeat=True,

--- a/edflow/iterators/batches.py
+++ b/edflow/iterators/batches.py
@@ -9,7 +9,6 @@ from edflow.iterators.resize import resize_hfloat32  # noqa
 
 from chainer.iterators import MultiprocessIterator
 
-# from chainer.dataset import DatasetMixin
 from edflow.data.dataset import DatasetMixin  # noqa
 
 
@@ -104,10 +103,7 @@ class Iterator(MultiprocessIterator):
             raise
 
     def __next__(self):
-        try:
-            return self._lod2dol(super(Iterator, self).__next__())
-        except BrokenPipeError:
-            pass
+        return self._lod2dol(super(Iterator, self).__next__())
 
     @property
     def n(self):

--- a/edflow/iterators/batches.py
+++ b/edflow/iterators/batches.py
@@ -1,6 +1,7 @@
 import numpy as np
 import PIL.Image
 import math
+import warnings
 from edflow.iterators.resize import resize_image  # noqa
 from edflow.iterators.resize import resize_uint8  # noqa
 from edflow.iterators.resize import resize_float32  # noqa
@@ -116,9 +117,13 @@ class Iterator(MultiprocessIterator):
         return math.ceil(self.n / self.batch_size)
 
 
-def make_batches(dataset, batch_size, shuffle, n_processes=8, n_prefetch=1):
+def make_batches(dataset, batch_size, shuffle, n_processes=8, n_prefetch=1, error_on_timeout=False):
     # the first n_processes / batch_size batches will be quite slow for some
     # reason
+    if error_on_timeout:
+        warnings.simplefilter(
+                'error',
+                MultiprocessIterator.TimeoutWarning)
     batches = Iterator(
         dataset,
         repeat=True,

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -110,6 +110,7 @@ def _train(config, root, checkpoint=None, retrain=False):
         shuffle=True,
         n_processes=n_processes,
         n_prefetch=n_prefetch,
+        error_on_timeout=config.get("error_on_timeout", False)
     ) as batches:
         # get them going
         logger.info("Warm up batches.")
@@ -184,6 +185,7 @@ def _test(config, root, checkpoint=None, nogpu=False, bar_position=0):
         shuffle=False,
         n_processes=n_processes,
         n_prefetch=n_prefetch,
+        error_on_timeout=config.get("error_on_timeout", False)
     )
     # get going
     next(batches)

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -110,7 +110,7 @@ def _train(config, root, checkpoint=None, retrain=False):
         shuffle=True,
         n_processes=n_processes,
         n_prefetch=n_prefetch,
-        error_on_timeout=config.get("error_on_timeout", False)
+        error_on_timeout=config.get("error_on_timeout", False),
     ) as batches:
         # get them going
         logger.info("Warm up batches.")
@@ -185,7 +185,7 @@ def _test(config, root, checkpoint=None, nogpu=False, bar_position=0):
         shuffle=False,
         n_processes=n_processes,
         n_prefetch=n_prefetch,
-        error_on_timeout=config.get("error_on_timeout", False)
+        error_on_timeout=config.get("error_on_timeout", False),
     )
     # get going
     next(batches)


### PR DESCRIPTION
- closes #151 : ignore sigint in children, i.e. dont raise KeyboardInterrupt
- we now exit with code 1 if the iteration is aborted due to something different than ctrl-c'ing, which might be useful for #100 , too
- `error_on_timeout` option, to transform the MultiProcessIterator's warning about a stalled dataset into an error