### PR TITLE
:tada: Add coveralls.io support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -38,7 +38,8 @@
       "avatar_url": "https://avatars1.githubusercontent.com/u/38811725?v=4",
       "profile": "https://github.com/rromb",
       "contributions": [
-        "tutorial"
+        "tutorial",
+        "doc"
       ]
     },
     {
@@ -48,7 +49,8 @@
       "profile": "https://github.com/ArWeHei",
       "contributions": [
         "doc",
-        "infra"
+        "infra",
+        "code"
       ]
     },
     {

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+# .coveragerc to control coverage.py
+[run]
+data_file = .coverage
+
+[report]
+# fail_under = $FAIL_PERCENT
+precision = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
 
 install: true
 
+after_success:
+  - coveralls
 
 # Run test
 jobs:
@@ -29,32 +31,24 @@ jobs:
         - pip install black
       script:
         - black --check .
+      after_success: skip
     - stage: documentation
       name: "documentation test"
       install:
         - pip install sphinx sphinx_rtd_theme sphinxcontrib-apidoc pyyaml numpy
       script:
         - sphinx-build -W -v -b html docs/ docs/_build/
-    - stage: general_tests
-      name: "General Tests"
-      install:
-        - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION tensorflow=1.13.1
-        - source activate test-environment
-        - conda install pytorch-cpu torchvision-cpu -c pytorch
-        - pip install tensorboardX
-        - python setup.py install
-      script:
-        - python -c "import skimage" # fix failing test due to static tls loading
-        - pytest --ignore=examples # use pytest instead of python -m pytest
+      after_success: skip
     - stage: tf_example_tests
       name: "Tensorflow examples test"
       install:
         - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION tensorflow=1.13.1
         - source activate test-environment
-        - python setup.py install
+        - pip install -e .[test]
       script:
         - cd examples
-        - python -m pytest -k tf
+        - pytest --cov edflow -k tf --cov-config .coveragerc --cov-append
+        - cd ..
     - stage: torch_example_tests
       name: "Pytorch examples test"
       install:
@@ -62,7 +56,19 @@ jobs:
         - source activate test-environment
         - conda install pytorch-cpu torchvision-cpu -c pytorch
         - pip install tensorboardX
-        - python setup.py install
+        - pip install -e .[test]
       script:
         - cd examples
-        - python -m pytest -k torch
+        - pytest --cov edflow -k torch --cov-config .coveragerc --cov-append
+        - cd ..
+    - stage: general_tests
+      name: "General Tests"
+      install:
+        - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION tensorflow=1.13.1
+        - source activate test-environment
+        - conda install pytorch-cpu torchvision-cpu -c pytorch
+        - pip install tensorboardX
+        - pip install -e .[test]
+      script:
+        - python -c "import skimage" # fix failing test due to static tls loading
+        - pytest --cov edflow --cov-config .coveragerc --ignore=examples # use pytest instead of python -m pytest

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ optional arguments:
 [![GitHub-Stars][GitHub-Stars]](https://github.com/pesser/edflow/stargazers)
 [![GitHub-Forks][GitHub-Forks]](https://github.com/pesser/edflow/network)
 [![GitHub-Updated][GitHub-Updated]](https://github.com/pesser/edflow/pulse)
+[![Coverage-Status][Coverage-Status]](https://coveralls.io/github/ArWeHei/edflow?branch=master)
 
 ## LICENSE
  
@@ -458,6 +459,8 @@ Mimo Tilbich [![GitHub-Contributions][GitHub-Contributions]](https://github.com/
 [GitHub-PRs]: https://img.shields.io/github/issues-pr-closed/pesser/edflow.svg?logo=github&logoColor=white
 [GitHub-Contributions]: https://img.shields.io/github/contributors/pesser/edflow.svg?logo=github&logoColor=white
 [GitHub-Updated]: https://img.shields.io/github/last-commit/pesser/edflow/master.svg?logo=github&logoColor=white&label=pushed
+[Coverage-Status]: https://coveralls.io/repos/github/ArWeHei/edflow/badge.svg?branch=master
+
 
 [LICENSE]: https://img.shields.io/github/license/pesser/edflow.svg
 
@@ -469,8 +472,8 @@ Mimo Tilbich [![GitHub-Contributions][GitHub-Contributions]](https://github.com/
   <tr>
     <td align="center"><a href="https://github.com/pesser"><img src="https://avatars3.githubusercontent.com/u/2175508?v=4" width="100px;" alt="Patrick Esser"/><br /><sub><b>Patrick Esser</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=pesser" title="Code">💻</a> <a href="#ideas-pesser" title="Ideas, Planning, & Feedback">🤔</a> <a href="#tutorial-pesser" title="Tutorials">✅</a></td>
     <td align="center"><a href="https://github.com/jhaux"><img src="https://avatars0.githubusercontent.com/u/9572598?v=4" width="100px;" alt="Johannes Haux"/><br /><sub><b>Johannes Haux</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=jhaux" title="Code">💻</a> <a href="https://github.com/pesser/edflow/commits?author=jhaux" title="Documentation">📖</a> <a href="#ideas-jhaux" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="https://github.com/rromb"><img src="https://avatars1.githubusercontent.com/u/38811725?v=4" width="100px;" alt="rromb"/><br /><sub><b>rromb</b></sub></a><br /><a href="#tutorial-rromb" title="Tutorials">✅</a></td>
-    <td align="center"><a href="https://github.com/ArWeHei"><img src="https://avatars2.githubusercontent.com/u/46443020?v=4" width="100px;" alt="arwehei"/><br /><sub><b>arwehei</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=ArWeHei" title="Documentation">📖</a> <a href="#infra-ArWeHei" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+    <td align="center"><a href="https://github.com/rromb"><img src="https://avatars1.githubusercontent.com/u/38811725?v=4" width="100px;" alt="rromb"/><br /><sub><b>rromb</b></sub></a><br /><a href="#tutorial-rromb" title="Tutorials">✅</a> <a href="https://github.com/pesser/edflow/commits?author=rromb" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/ArWeHei"><img src="https://avatars2.githubusercontent.com/u/46443020?v=4" width="100px;" alt="arwehei"/><br /><sub><b>arwehei</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=ArWeHei" title="Documentation">📖</a> <a href="#infra-ArWeHei" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/pesser/edflow/commits?author=ArWeHei" title="Code">💻</a></td>
     <td align="center"><a href="http://sandrobraun.de"><img src="https://avatars0.githubusercontent.com/u/6517465?v=4" width="100px;" alt="Sandro Braun"/><br /><sub><b>Sandro Braun</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=theRealSuperMario" title="Code">💻</a> <a href="#example-theRealSuperMario" title="Examples">💡</a> <a href="https://github.com/pesser/edflow/commits?author=theRealSuperMario" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://conrad-sachweh.de"><img src="https://avatars0.githubusercontent.com/u/6422533?v=4" width="100px;" alt="Conrad Sachweh"/><br /><sub><b>Conrad Sachweh</b></sub></a><br /><a href="https://github.com/pesser/edflow/commits?author=conrad784" title="Documentation">📖</a> <a href="https://github.com/pesser/edflow/commits?author=conrad784" title="Tests">⚠️</a></td>
     <td align="center"><a href="https://github.com/mritv"><img src="https://avatars1.githubusercontent.com/u/39053439?v=4" width="100px;" alt="Ritvik Marwaha"/><br /><sub><b>Ritvik Marwaha</b></sub></a><br /><a href="#example-mritv" title="Examples">💡</a></td>

--- a/examples/.coveragerc
+++ b/examples/.coveragerc
@@ -1,0 +1,7 @@
+# .coveragerc to control coverage.py
+[run]
+data_file = ../.coverage
+
+[report]
+# fail_under = $FAIL_PERCENT
+precision = 2

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,13 @@ setup(
         "scikit-image",
         "pandas",
         "psutil",
-        "pytest",
         "deprecated",
         "fastnumbers",
     ],
-    extras_require={"docs": ["sphinx >= 1.4", "sphinx_rtd_theme", "numpy"]},
+    extras_require={
+        "docs": ["sphinx >= 1.4", "sphinx_rtd_theme", "numpy"],
+        "test": ["pytest", "pytest-cov", "coveralls"],
+    },
     zip_safe=False,
     scripts=[
         "edflow/edflow",


### PR DESCRIPTION
Now edflow test coverage is tracked by coveralls.io and we added a badge as well :+1:.
Also it is now possible to let PRs fail if the coverage decreases by x% :tada: