### PR TITLE
Deep batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LambdaCheckpointHook` uses global step and doesn't save on first step.
 - Switched opencv2 functions with manual ones to get rid of the dependency.
 - `edeval` now allows for differnet callback interface via the config. Callbacks are now entered as `dicts`, which allows to also pass keyword arguments to the callbacks from the config.
+- `make_batches` now produces deep batches of examples. See documentation of `deep_lod2dol` or the section "Datasets and Batching" in the documention.
 
 ### Removed
 - It is no longer possible to pass callbacks as list via the config

--- a/docs/source/dataset_and_batching.rst
+++ b/docs/source/dataset_and_batching.rst
@@ -38,6 +38,38 @@ config.
 Batches are automatically created based on the key ``batch_size`` which you
 specify in the config.
 
+A cool feature when working with examples of nested dictionaries is, that they
+behave the same as their batch versions! I.e. you can access the same keys in
+the same order in a single example and in a batch of examples and still end up
+at the value or batch ofl values you would expect.
+
+.. code-block:: python
+
+    example = {'a': 1, 'b': {'c': 1}, 'd': [1, 2]}
+
+    # after applting our batching algorithm on a list of three of the above examples:
+    batch_of_3_examples = {'a': [1, 1, 1], 'b': {'c': [1, 1, 1]}, 'd': [[1, 1, 1], [2, 2, 2]]}
+
+    example['a'] == 1  # True
+    example['d'][0] == 1  # True
+
+    batch_of_3_examples['a'] == [1, 1, 1]  # True
+    batch_of_3_examples['d'][0] == [1, 1, 1]  # True
+
+This comes in especially handy when you use the utility functions found at
+``edflow.util`` for handling nested structures, as you now can use the same
+keys anytime:
+
+.. code-block:: python
+
+    from edflow.util import retrieve
+
+    retrieve(example, 'a') == 1  # True
+    retrieve(example, 'd/0') == 1  # True
+
+    retrieve(batch_of_3_examples, 'a') == [1, 1, 1]  # True
+    retrieve(batch_of_3_examples, 'd/0') == [1, 1, 1]  # True
+
 .. One of the advantages of **EDFLow** is, that if your model runs with a batch
    size of one, it runs with any batch size.
 

--- a/edflow/iterators/batches.py
+++ b/edflow/iterators/batches.py
@@ -86,7 +86,7 @@ def batch_to_canvas(X, cols=None):
     return canvas
 
 
-def deep_lod2dol(list_of_nested_things):
+def _deep_lod2dol(list_of_nested_things):
     """Turns a list of nested dictionaries into a nested dictionary of lists.
     This function takes care that all leafs of the nested dictionaries are 
     considered as full keys, not only the top level keys.
@@ -133,7 +133,7 @@ def deep_lod2dol(list_of_nested_things):
     return out
 
 
-def deep_lod2dol_v2(list_of_nested_things):
+def _deep_lod2dol_v2(list_of_nested_things):
     """Turns a list of nested dictionaries into a nested dictionary of lists.
     This function takes care that all leafs of the nested dictionaries are 
     considered as full keys, not only the top level keys.
@@ -177,7 +177,7 @@ def deep_lod2dol_v2(list_of_nested_things):
     return out
 
 
-def deep_lod2dol_v3(list_of_nested_things):
+def _deep_lod2dol_v3(list_of_nested_things):
     """Turns a list of nested dictionaries into a nested dictionary of lists.
     This function takes care that all leafs of the nested dictionaries are 
     considered as full keys, not only the top level keys.
@@ -227,15 +227,15 @@ def _benchmark_deep_lod2dol():
 
         with timing("v1@{: >4}".format(bs), N):
             for i in range(N):
-                deep_lod2dol(lod)
+                _deep_lod2dol(lod)
 
         with timing("v2@{: >4}".format(bs), N):
             for i in range(N):
-                deep_lod2dol_v2(lod)
+                _deep_lod2dol_v2(lod)
 
         with timing("v3@{: >4}".format(bs), N):
             for i in range(N):
-                deep_lod2dol_v3(lod)
+                _deep_lod2dol_v3(lod)
 
         print("-" * 15)
 
@@ -262,11 +262,14 @@ def _benchmark_deep_lod2dol():
     # ---------------
 
 
+deep_lod2dol = _deep_lod2dol_v2
+
+
 class Iterator(MultiprocessIterator):
     """Iterator that converts a list of dicts into a dict of lists."""
 
     def __next__(self):
-        return deep_lod2dol_v2(super(Iterator, self).__next__())
+        return deep_lod2dol(super(Iterator, self).__next__())
 
     @property
     def n(self):

--- a/edflow/iterators/batches.py
+++ b/edflow/iterators/batches.py
@@ -93,19 +93,19 @@ def deep_lod2dol(list_of_nested_things):
 
     Parameters
     ----------
-    list_of_nested_things : list(dict(anything))
-        A list of deep dictionaries
+    list_of_nested_things : list
+        A list of deep nested dictionaries.
 
     Returns
     -------
-    out : dict(anything(list))
+    out : dict
         A dict containing lists of leaf entries.
 
     Raises
     ------
     ValueError
-        Raised if the passed object is not a `list` or if its values are not
-        `dict`s.
+        Raised if the passed object is not a ``list`` or if its values are not
+        ``dict``s.
     """
 
     # Put custom exceptions in try excepts so that we do not check everytime
@@ -146,12 +146,12 @@ def deep_lod2dol_v2(list_of_nested_things):
 
     Parameters
     ----------
-    list_of_nested_things : list(dict(anything))
+    list_of_nested_things : list
         A list of deep dictionaries
 
     Returns
     -------
-    out : dict(anything(list))
+    out : dict
         A dict containing lists of leaf entries.
 
     Raises

--- a/edflow/util.py
+++ b/edflow/util.py
@@ -544,6 +544,21 @@ def contains_key(nested_thing, key, splitval="/", expand=True):
         return False
 
 
+def get_leaf_names(nested_thing):
+    class LeafGetter:
+        def __call__(self, key, value):
+            if not hasattr(self, "keys"):
+                self.keys = []
+
+            self.keys += [key]
+
+    LG = LeafGetter()
+
+    walk(nested_thing, LG, pass_key=True)
+
+    return LG.keys
+
+
 def strenumerate(iterable):
     """Works just as enumerate, but the returned index is a string.
 

--- a/tests/test_iterators/test_batches.py
+++ b/tests/test_iterators/test_batches.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from edflow.iterators import batches
+from edflow.util import get_leaf_names, retrieve
 
 
 def test_batch_to_canvas():
@@ -19,3 +20,99 @@ def test_batch_to_canvas():
 
     canvas = batches.batch_to_canvas(x, cols=None)
     assert canvas.shape == (300, 300, 3)
+
+
+def test_deep_lod2dol():
+    lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
+
+    dol = batches.deep_lod2dol(lod)
+
+    ref = {
+        "a": np.array([1, 1, 1]),
+        "b": {
+            "c": np.array([1, 1, 1]),
+            "d": [np.array([1, 1, 1]), np.array([2, 2, 2])],
+        },
+        "e": [{"a": np.array([1, 1, 1])}] * 2,
+    }
+
+    assert get_leaf_names(dol) == get_leaf_names(ref)
+
+    for k in get_leaf_names(dol):
+        assert all(retrieve(dol, k) == retrieve(ref, k))
+
+
+def test_deep_lod2dol_wrong_inputs():
+    lod = [[1, 2, 3], {"a": 1}]
+
+    with pytest.raises(TypeError):
+        dol = batches.deep_lod2dol(lod)
+
+    lod = {"a": [1, 2, 3], "b": {"a": 1}}
+
+    with pytest.raises(TypeError):
+        dol = batches.deep_lod2dol(lod)
+
+
+def test_deep_lod2dol_v2():
+    lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
+
+    dol = batches.deep_lod2dol_v2(lod)
+
+    ref = {
+        "a": np.array([1, 1, 1]),
+        "b": {
+            "c": np.array([1, 1, 1]),
+            "d": [np.array([1, 1, 1]), np.array([2, 2, 2])],
+        },
+        "e": [{"a": np.array([1, 1, 1])}] * 2,
+    }
+
+    assert get_leaf_names(dol) == get_leaf_names(ref)
+
+    for k in get_leaf_names(dol):
+        assert all(retrieve(dol, k) == retrieve(ref, k))
+
+
+def test_deep_lod2dol_v2_wrong_inputs():
+    lod = [[1, 2, 3], {"a": 1}]
+
+    with pytest.raises(TypeError):
+        dol = batches.deep_lod2dol_v2(lod)
+
+    lod = {"a": [1, 2, 3], "b": {"a": 1}}
+
+    with pytest.raises(TypeError):
+        dol = batches.deep_lod2dol_v2(lod)
+
+
+def test_deep_lod2dol_v3():
+    lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
+
+    dol = batches.deep_lod2dol_v3(lod)
+
+    ref = {
+        "a": np.array([1, 1, 1]),
+        "b": {
+            "c": np.array([1, 1, 1]),
+            "d": [np.array([1, 1, 1]), np.array([2, 2, 2])],
+        },
+        "e": [{"a": np.array([1, 1, 1])}] * 2,
+    }
+
+    assert get_leaf_names(dol) == get_leaf_names(ref)
+
+    for k in get_leaf_names(dol):
+        assert all(retrieve(dol, k) == retrieve(ref, k))
+
+
+def test_deep_lod2dol_v3_wrong_inputs():
+    lod = [[1, 2, 3], {"a": 1}]
+
+    with pytest.raises(Exception):
+        dol = batches.deep_lod2dol_v3(lod)
+
+    lod = {"a": [1, 2, 3], "b": {"a": 1}}
+
+    with pytest.raises(Exception):
+        dol = batches.deep_lod2dol_v3(lod)

--- a/tests/test_iterators/test_batches.py
+++ b/tests/test_iterators/test_batches.py
@@ -25,7 +25,7 @@ def test_batch_to_canvas():
 def test_deep_lod2dol():
     lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
 
-    dol = batches.deep_lod2dol(lod)
+    dol = batches._deep_lod2dol(lod)
 
     ref = {
         "a": np.array([1, 1, 1]),
@@ -46,18 +46,18 @@ def test_deep_lod2dol_wrong_inputs():
     lod = [[1, 2, 3], {"a": 1}]
 
     with pytest.raises(TypeError):
-        dol = batches.deep_lod2dol(lod)
+        dol = batches._deep_lod2dol(lod)
 
     lod = {"a": [1, 2, 3], "b": {"a": 1}}
 
     with pytest.raises(TypeError):
-        dol = batches.deep_lod2dol(lod)
+        dol = batches._deep_lod2dol(lod)
 
 
 def test_deep_lod2dol_v2():
     lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
 
-    dol = batches.deep_lod2dol_v2(lod)
+    dol = batches._deep_lod2dol_v2(lod)
 
     ref = {
         "a": np.array([1, 1, 1]),
@@ -78,18 +78,18 @@ def test_deep_lod2dol_v2_wrong_inputs():
     lod = [[1, 2, 3], {"a": 1}]
 
     with pytest.raises(TypeError):
-        dol = batches.deep_lod2dol_v2(lod)
+        dol = batches._deep_lod2dol_v2(lod)
 
     lod = {"a": [1, 2, 3], "b": {"a": 1}}
 
     with pytest.raises(TypeError):
-        dol = batches.deep_lod2dol_v2(lod)
+        dol = batches._deep_lod2dol_v2(lod)
 
 
 def test_deep_lod2dol_v3():
     lod = [{"a": 1, "b": {"c": 1, "d": [1, 2]}, "e": [{"a": 1}] * 2}] * 3
 
-    dol = batches.deep_lod2dol_v3(lod)
+    dol = batches._deep_lod2dol_v3(lod)
 
     ref = {
         "a": np.array([1, 1, 1]),
@@ -110,9 +110,9 @@ def test_deep_lod2dol_v3_wrong_inputs():
     lod = [[1, 2, 3], {"a": 1}]
 
     with pytest.raises(Exception):
-        dol = batches.deep_lod2dol_v3(lod)
+        dol = batches._deep_lod2dol_v3(lod)
 
     lod = {"a": [1, 2, 3], "b": {"a": 1}}
 
     with pytest.raises(Exception):
-        dol = batches.deep_lod2dol_v3(lod)
+        dol = batches._deep_lod2dol_v3(lod)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ from edflow.util import (
     set_default,
     contains_key,
     KeyNotFoundError,
+    get_leaf_names,
 )
 from edflow import util
 from itertools import product
@@ -744,3 +745,16 @@ def test_contains_key_callable():
     assert not contains_key(dol, "f", expand=True)
     dol = {"a": [1, 2], "b": callable_leave, "e": 2}  # reset
     assert not contains_key(dol, "f", expand=False)
+
+
+# ================== leaf names ==================
+
+
+def test_get_leaf_name():
+    dol = {"a": [1, 2], "b": {"c": {"d": 1}}, "e": 2}
+
+    names = sorted(get_leaf_names(dol))
+
+    ref = sorted(["a/0", "a/1", "b/c/d", "e"])
+
+    assert names == ref


### PR DESCRIPTION
This PR allows batching to now support deep conversion of list to dict, i.e. a list of nested dicts are converted to nested dicts with lists at the leafs.

I implemented 3 versions of this new `deep_lod2dol` function, 2 with comprehensive Error Messages and on without and benchmarked them using `_benchmark_deep_lod2dol`. See the function for the results. I used the faster of the comprehensive versions in the `MultiprocessIterator`.

In the past a batch of examples would be converted like this:
``` python
[{'a': {'b': 1}}, {'a': {'b': 2}}, {'a': {'b': 3}}] 
=> 
{'a': [{'b': 1}, {'b': 2}, {'b': 3}]}
```
Now it will be converted like this:
``` python
[{'a': {'b': 1}}, {'a': {'b': 2}}, {'a': {'b': 3}}] 
=> 
{'a': {'b': [1, 2, 3]}}
```

I implemented this functionality as it allows me to put examples inside examples and still access their content without having to consider the batch dimension should it exist.