### PR TITLE
Adds strategies how to handle bad frame indices to SequenceDataset

### DIFF
--- a/tests/test_data/test_believers/test_sequence.py
+++ b/tests/test_data/test_believers/test_sequence.py
@@ -72,6 +72,35 @@ def test_seq_wrong_fid_len():
         S = SequenceDataset(D, 3, fid_key="label1")
 
 
+def test_seq_offset_fid_strat_remove():
+    D1 = DebugDataset(size=10)
+    D2 = DebugDataset(size=10, offset=3)
+
+    D = D1 + D2
+
+    S = SequenceDataset(D, 3, fid_key="label1", strategy="remove")
+
+    assert len(S) == (len(D1) - 2)
+
+
+def test_seq_offset_fid_strat_reset():
+    D1 = DebugDataset(size=10)
+    D2 = DebugDataset(size=12, offset=3)
+
+    D = D1 + D2
+
+    S = SequenceDataset(D, 3, fid_key="label1", strategy="reset")
+
+    assert len(S) == (len(D1) - 2 + len(D2) - 2)
+
+
+def test_seq_offset_fid_strat_unknown():
+    D = DebugDataset(size=12, offset=3)
+
+    with pytest.raises(ValueError):
+        S = SequenceDataset(D, 3, fid_key="label1", strategy="recolorize")
+
+
 # =============================================================================
 
 


### PR DESCRIPTION
For example useful when doing cleanups in your dataset and you now have messed up sequences.
The strategies are as follows:
``` python
fid: [0, 1, 2, 2, 3, 0, 1, 2]  # Labels used to generate sequences
raises: ValueError  # Throw an error and let the user figure out what's wrong. (Default)
remove:  [0, 1, 2, 0, 1, 2]  # Remove bad sequences
reset:  [0, 1, 2, 0, 1, 0, 1, 2]  # Reset bad sequences
```

Implemented 'cause I need it. :smile: