### PR TITLE
Sigpipe

### DIFF
--- a/edflow/edflow
+++ b/edflow/edflow
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import os
+# directly terminate on broken pipe without throwing exception
 import signal
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 import sys  # noqa
 

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -5,11 +5,6 @@ import yaml
 import math
 import datetime
 
-# ignore broken pipe errors: https://www.quora.com/How-can-you-avoid-a-broken-pipe-error-on-Python
-from signal import signal, SIGPIPE, SIG_DFL
-
-signal(SIGPIPE, SIG_DFL)
-
 import multiprocessing as mp
 import traceback
 


### PR DESCRIPTION
builds on top of #183 
one cannot set signal handling in child threads. this prevented any code which imported `edflow.main` to be run in threads. now signal handling is set directly in the edflow executable which is not expected to be run in threads.