### PR TITLE
Create Dataset DisjunctExampleConcatenatedDataset

### DIFF
--- a/edflow/data/dataset.py
+++ b/edflow/data/dataset.py
@@ -44,6 +44,7 @@ from edflow.data.dataset_mixin import DatasetMixin
 from edflow.data.agnostics.subdataset import SubDataset
 from edflow.data.agnostics.concatenated import ConcatenatedDataset
 from edflow.data.agnostics.concatenated import ExampleConcatenatedDataset
+from edflow.data.agnostics.concatenated import DisjunctExampleConcatenatedDataset
 from edflow.data.agnostics.csv_dset import CsvDataset
 
 from edflow.data.believers.sequence import SequenceDataset, UnSequenceDataset

--- a/edflow/debug.py
+++ b/edflow/debug.py
@@ -27,23 +27,40 @@ class DebugIterator(PyHookedModelIterator):
 
 
 class DebugDataset(DatasetMixin):
-    def __init__(self, size=100, offset=0, *args, **kwargs):
+    def __init__(
+        self,
+        size=100,
+        offset=0,
+        other_labels=False,
+        other_ex_keys=False,
+        *args,
+        **kwargs
+    ):
         self.size = size
         self.offset = offset
+        self.other_labels = other_labels
+        self.other_ex_keys = other_ex_keys
 
     def get_example(self, i):
         if i < self.size:
             i += self.offset
-            return {"val": i, "index_": i, "other": i}
+            if self.other_ex_keys:
+                ex = {"val_other": i, "other_other": i}
+            else:
+                ex = {"val": i, "other": i}
+            return dict({"index_": i}, **ex)
         else:
             raise IndexError("Out of bounds")
 
     @property
     def labels(self):
         if not hasattr(self, "_labels"):
+            if self.other_labels:
+                keys = ["label1_other", "label2_other"]
+            else:
+                keys = ["label1", "label2"]
             self._labels = {
-                k: [i + self.offset for i in range(self.size)]
-                for k in ["label1", "label2"]
+                k: [i + self.offset for i in range(self.size)] for k in keys
             }
         return self._labels
 


### PR DESCRIPTION
This dataset class is able to join two disjunct datasets. This usefull for example for a dataset containing images and another dataset containing the generated flows between frames of the first dataset.