### PR TITLE
Meta Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added MetaDataset for easy Dataloading
 - Added CelebA dataset.
 - Added CIFAR10 dataset.
 - Environment variable EDFLOW\_GIT enables git integration.

--- a/docs/source/source_files/edflow.data.believers.rst
+++ b/docs/source/source_files/edflow.data.believers.rst
@@ -4,6 +4,22 @@ edflow.data.believers package
 Submodules
 ----------
 
+edflow.data.believers.meta module
+---------------------------------
+
+.. automodule:: edflow.data.believers.meta
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+edflow.data.believers.meta\_loaders module
+------------------------------------------
+
+.. automodule:: edflow.data.believers.meta_loaders
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 edflow.data.believers.sequence module
 -------------------------------------
 

--- a/docs/source/source_files/edflow.datasets.rst
+++ b/docs/source/source_files/edflow.datasets.rst
@@ -4,6 +4,22 @@ edflow.datasets package
 Submodules
 ----------
 
+edflow.datasets.celeba module
+-----------------------------
+
+.. automodule:: edflow.datasets.celeba
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+edflow.datasets.cifar module
+----------------------------
+
+.. automodule:: edflow.datasets.cifar
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 edflow.datasets.fashionmnist module
 -----------------------------------
 

--- a/edflow/data/believers/meta.py
+++ b/edflow/data/believers/meta.py
@@ -30,37 +30,40 @@ class MetaDataset(DatasetMixin):
     getitem method of the dataset, a special loader function will be called.
 
     Let's take a look at an example data folder of the following structure:
-    ```
-    root/
-    ├ meta.yaml
-    ├ images/
-    │  ├ image_1.png
-    │  ├ image_2.png
-    │  ├ image_3.png
-    ...
-    │  └ image_10000.png
-    ├ image:image-*-10000-*-str.npy
-    ├ attr1-*-10000-*-int.npy
-    ├ attr2-*-10000x2-*-int.npy
-    └ kps-*-10000x17x3-*-int.npy
-    ```
+    .. code-block:: bash
+
+        root/
+        ├ meta.yaml
+        ├ images/
+        │  ├ image_1.png
+        │  ├ image_2.png
+        │  ├ image_3.png
+        ...
+        │  └ image_10000.png
+        ├ image:image-*-10000-*-str.npy
+        ├ attr1-*-10000-*-int.npy
+        ├ attr2-*-10000x2-*-int.npy
+        └ kps-*-10000x17x3-*-int.npy
+
 
     The ``meta.yaml`` file looks like this:
-    ```
-    description: |
-        This is a dataset which loads images.
-        All paths to the images are in the label `image`.
 
-    loader_kwargs:
-        image:
-            support: "-1->1"
-    ```
+    .. code-block:: yaml
+
+        description: |
+            This is a dataset which loads images.
+            All paths to the images are in the label `image`.
+
+        loader_kwargs:
+            image:
+                support: "-1->1"
+
 
     The resulting dataset has the following labels:
-    - ``image_``: the paths to the images. Note the extra `_` at the end.
-    - ``attr1``
-    - ``attr2``
-    - ``kps``
+        - ``image_``: the paths to the images. Note the extra ``_`` at the end.
+        - ``attr1``
+        - ``attr2``
+        - ``kps``
 
     When using the ``__getitem__`` method of the dataset, the image loader will
     be applied to the image label at the given index and the image will be
@@ -137,26 +140,26 @@ class MetaDataset(DatasetMixin):
 
 def setup_loaders(labels, meta_dict):
     """Creates a map of key -> function pairs, which can be used to postprocess
-    label values at each ``getitem`` call.
+    label values at each ``__getitem__`` call.
+
+    Loaders defined in :attr:`meta_dict` supersede those definde in the label
+    keys.
 
     Parameters
     ----------
-    labels : dict(str, numpy.ndarray)
+    labels : dict(str, numpy.memmap)
         Labels contain all load-easy dataset relevant data. If the key follows
         the pattern ``name:loader``, this function will try to finde the
-        corresponding loader in :attr:`DEFAULT_LOADERS``.
+        corresponding loader in :attr:`DEFAULT_LOADERS`.
     meta_dict : dict
         A dictionary containing all dataset relevent information, which is the
         same for all examples. This function will try to find the entry
         ``loaders`` in the dictionary, which must contain another ``dict`` with
         ``name:loader`` pairs. Here ``loader`` must be either an entry in
-        :attr:`DEFAULT_LOADERS`` or a loadable import path.
+        :attr:`DEFAULT_LOADERS` or a loadable import path.
         You can additionally define an entry ``loader_kwargs``, which must
         contain ``name:dict`` pairs. The dictionary is passed as keyword
         arguments to the loader corresponding to ``name``.
-
-    Loaders defined in :attr:`meta_dict` supersede those definde in the label
-    keys.
 
     Returns
     -------
@@ -197,19 +200,17 @@ def setup_loaders(labels, meta_dict):
 
 def load_labels(root):
     """
-
     Parameters
     ----------
     root : str
-        Where to look for the labels
-
+        Where to look for the labels.
 
     Returns
     -------
     labels : dict
-        All labels as ``np.memmap``s.
-
+        All labels as ``np.memmap`` s.
     """
+
     regex = re.compile(r".*-\*-.*-\*-.*\.npy")
 
     files = os.listdir(root)

--- a/edflow/data/believers/meta.py
+++ b/edflow/data/believers/meta.py
@@ -16,10 +16,7 @@ except ImportError:
     __COULD_HAVE_IPYTHON__ = False
 
 
-DEFAULT_LOADERS = {
-        'image': image_loader,
-        'np': numpy_loader
-        }
+DEFAULT_LOADERS = {"image": image_loader, "np": numpy_loader}
 
 
 class MetaDataset(DatasetMixin):
@@ -74,34 +71,44 @@ class MetaDataset(DatasetMixin):
     """
 
     def __init__(self, root):
-        '''
+        """
         Parameters
         ----------
         root : str
             Where to look for all the data.
-        '''
-        meta_path = os.path.join(root, 'meta.yaml')
-        self.meta = meta = yaml.safe_load(open(meta_path, 'r'))
+        """
+        meta_path = os.path.join(root, "meta.yaml")
+        self.meta = meta = yaml.safe_load(open(meta_path, "r"))
 
         labels = load_labels(root)
         self.loaders, self.loader_kwargs = setup_loaders(labels, meta)
         self.labels = clean_keys(labels)
 
+        lens = []
+        for k in self.labels.keys():
+            lens += [len(self.labels[k])]
+        assert all(x == lens[0] for x in lens)
+
+        self.num_examples = lens[0]
+
         self.append_labels = True
 
+    def __len__(self):
+        return self.num_examples
+
     def get_example(self, idx):
-        '''Loads all loadable data from the labels.
+        """Loads all loadable data from the labels.
         
         Parameters
         ----------
         idx : int
             The index of the example to load
-        '''
+        """
         example = {}
 
         for key, loader in self.loaders.items():
             kwargs = self.loader_kwargs[key]
-            example[key] = loader(self.labels[key + '_'][idx], **kwargs)
+            example[key] = loader(self.labels[key + "_"][idx], **kwargs)
 
         return example
 
@@ -111,9 +118,9 @@ class MetaDataset(DatasetMixin):
         else:
             label_str = pp2mkdtable(self.labels, False)
 
-        descr = self.meta.get('description', 'MetaDataset')
+        descr = self.meta.get("description", "MetaDataset")
 
-        repr_str = f'{descr}\n\n# Labels\n{label_str}'
+        repr_str = f"{descr}\n\n# Labels\n{label_str}"
 
         return repr_str
 
@@ -121,16 +128,15 @@ class MetaDataset(DatasetMixin):
         repr_str = self.__repr__()
 
         if __COULD_HAVE_IPYTHON__ and "IPKernelApp" in get_ipython().config:
-            repr_str += f'\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}'
+            repr_str += f"\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}"
             display(Markdown(repr_str))
         else:
-            repr_str += f'\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}'
+            repr_str += f"\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}"
             print(repr_str)
-        
 
 
 def setup_loaders(labels, meta_dict):
-    '''Creates a map of key -> function pairs, which can be used to postprocess
+    """Creates a map of key -> function pairs, which can be used to postprocess
     label values at each ``getitem`` call.
 
     Parameters
@@ -160,7 +166,7 @@ def setup_loaders(labels, meta_dict):
     loader_kwargs : dict
         Name, dict pairs. The dicts are passed to the loader functions as
         keyword arguments.
-    '''
+    """
 
     loaders = {}
     loader_kwargs = {}
@@ -170,8 +176,8 @@ def setup_loaders(labels, meta_dict):
         if l is not None:
             loaders[k] = l
 
-    meta_loaders = retrieve(meta_dict, 'loaders', default={})
-    meta_loader_kwargs = retrieve(meta_dict, 'loader_kwargs', default={})
+    meta_loaders = retrieve(meta_dict, "loaders", default={})
+    meta_loader_kwargs = retrieve(meta_dict, "loader_kwargs", default={})
 
     loaders.update(meta_loaders)
 
@@ -223,7 +229,7 @@ def load_labels(root):
 
 
 def clean_keys(labels):
-    '''Removes all loader inforamtion from the keys.
+    """Removes all loader inforamtion from the keys.
 
     Parameters
     ----------
@@ -234,12 +240,12 @@ def clean_keys(labels):
     -------
     labels : dict(str, numpy.memmap)
         The original labels, with keys without the ``:loader`` part.
-    '''
+    """
 
     for k_ in list(labels.keys()):
         k, l = loader_from_key(k_)
         if l is not None:
-            k = k + '_'
+            k = k + "_"
             labels[k] = labels[k_]
             del labels[k_]
         else:
@@ -249,8 +255,8 @@ def clean_keys(labels):
 
 
 def loader_from_key(key):
-    '''Returns the name, loader pair given a key.'''
+    """Returns the name, loader pair given a key."""
 
-    if ':' in key:
-        return key.split(':')
+    if ":" in key:
+        return key.split(":")
     return key, None

--- a/edflow/data/believers/meta.py
+++ b/edflow/data/believers/meta.py
@@ -1,0 +1,256 @@
+import os
+import numpy as np
+import yaml
+import re
+
+from edflow.data.dataset_mixin import DatasetMixin
+from edflow.util import retrieve, get_obj_from_str, pp2mkdtable
+from edflow.data.believers.meta_loaders import image_loader, numpy_loader
+
+try:
+    from IPython import get_ipython
+    from IPython.display import display, Markdown
+
+    __COULD_HAVE_IPYTHON__ = True
+except ImportError:
+    __COULD_HAVE_IPYTHON__ = False
+
+
+DEFAULT_LOADERS = {
+        'image': image_loader,
+        'np': numpy_loader
+        }
+
+
+class MetaDataset(DatasetMixin):
+    """
+    The :class:`MetaDataset` allows for easy data reading using a simple
+    interface.
+
+    All you need to do is hand the constructor a path and it will look for all
+    data in a special format and load it as numpy arrays. If further specified
+    in a meta data file or the name of the label array, when calling the
+    getitem method of the dataset, a special loader function will be called.
+
+    Let's take a look at an example data folder of the following structure:
+    ```
+    root/
+    ├ meta.yaml
+    ├ images/
+    │  ├ image_1.png
+    │  ├ image_2.png
+    │  ├ image_3.png
+    ...
+    │  └ image_10000.png
+    ├ image:image-*-10000-*-str.npy
+    ├ attr1-*-10000-*-int.npy
+    ├ attr2-*-10000x2-*-int.npy
+    └ kps-*-10000x17x3-*-int.npy
+    ```
+
+    The ``meta.yaml`` file looks like this:
+    ```
+    description: |
+        This is a dataset which loads images.
+        All paths to the images are in the label `image`.
+
+    loader_kwargs:
+        image:
+            support: "-1->1"
+    ```
+
+    The resulting dataset has the following labels:
+    - ``image_``: the paths to the images. Note the extra `_` at the end.
+    - ``attr1``
+    - ``attr2``
+    - ``kps``
+
+    When using the ``__getitem__`` method of the dataset, the image loader will
+    be applied to the image label at the given index and the image will be
+    loaded from the given path.
+
+    As we have specifed loader kweyword arguments, we will get the images with
+    a support of ``[-1, 1]``.
+    """
+
+    def __init__(self, root):
+        '''
+        Parameters
+        ----------
+        root : str
+            Where to look for all the data.
+        '''
+        meta_path = os.path.join(root, 'meta.yaml')
+        self.meta = meta = yaml.safe_load(open(meta_path, 'r'))
+
+        labels = load_labels(root)
+        self.loaders, self.loader_kwargs = setup_loaders(labels, meta)
+        self.labels = clean_keys(labels)
+
+        self.append_labels = True
+
+    def get_example(self, idx):
+        '''Loads all loadable data from the labels.
+        
+        Parameters
+        ----------
+        idx : int
+            The index of the example to load
+        '''
+        example = {}
+
+        for key, loader in self.loaders.items():
+            kwargs = self.loader_kwargs[key]
+            example[key] = loader(self.labels[key + '_'][idx], **kwargs)
+
+        return example
+
+    def __repr__(self):
+        if __COULD_HAVE_IPYTHON__ and "IPKernelApp" in get_ipython().config:
+            label_str = pp2mkdtable(self.labels, True)
+        else:
+            label_str = pp2mkdtable(self.labels, False)
+
+        descr = self.meta.get('description', 'MetaDataset')
+
+        repr_str = f'{descr}\n\n# Labels\n{label_str}'
+
+        return repr_str
+
+    def show(self):
+        repr_str = self.__repr__()
+
+        if __COULD_HAVE_IPYTHON__ and "IPKernelApp" in get_ipython().config:
+            repr_str += f'\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}'
+            display(Markdown(repr_str))
+        else:
+            repr_str += f'\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}'
+            print(repr_str)
+        
+
+
+def setup_loaders(labels, meta_dict):
+    '''Creates a map of key -> function pairs, which can be used to postprocess
+    label values at each ``getitem`` call.
+
+    Parameters
+    ----------
+    labels : dict(str, numpy.ndarray)
+        Labels contain all load-easy dataset relevant data. If the key follows
+        the pattern ``name:loader``, this function will try to finde the
+        corresponding loader in :attr:`DEFAULT_LOADERS``.
+    meta_dict : dict
+        A dictionary containing all dataset relevent information, which is the
+        same for all examples. This function will try to find the entry
+        ``loaders`` in the dictionary, which must contain another ``dict`` with
+        ``name:loader`` pairs. Here ``loader`` must be either an entry in
+        :attr:`DEFAULT_LOADERS`` or a loadable import path.
+        You can additionally define an entry ``loader_kwargs``, which must
+        contain ``name:dict`` pairs. The dictionary is passed as keyword
+        arguments to the loader corresponding to ``name``.
+
+    Loaders defined in :attr:`meta_dict` supersede those definde in the label
+    keys.
+
+    Returns
+    -------
+    loaders : dict
+        Name, function pairs, to apply loading logic based on the labels with
+        the specified names.
+    loader_kwargs : dict
+        Name, dict pairs. The dicts are passed to the loader functions as
+        keyword arguments.
+    '''
+
+    loaders = {}
+    loader_kwargs = {}
+
+    for k in labels.keys():
+        k, l = loader_from_key(k)
+        if l is not None:
+            loaders[k] = l
+
+    meta_loaders = retrieve(meta_dict, 'loaders', default={})
+    meta_loader_kwargs = retrieve(meta_dict, 'loader_kwargs', default={})
+
+    loaders.update(meta_loaders)
+
+    for k, l in loaders.items():
+        if l in DEFAULT_LOADERS:
+            loaders[k] = DEFAULT_LOADERS[l]
+        else:
+            loaders[k] = get_obj_from_str(l)
+
+        if k in meta_loader_kwargs:
+            loader_kwargs[k] = meta_loader_kwargs[k]
+        else:
+            loader_kwargs[k] = {}
+
+    return loaders, loader_kwargs
+
+
+def load_labels(root):
+    """
+
+    Parameters
+    ----------
+    root : str
+        Where to look for the labels
+
+
+    Returns
+    -------
+    labels : dict
+        All labels as ``np.memmap``s.
+
+    """
+    regex = re.compile(r".*-\*-.*-\*-.*\.npy")
+
+    files = os.listdir(root)
+    label_files = [f for f in files if regex.match(f) is not None]
+
+    labels = {}
+    for f in label_files:
+        f_ = f.strip(".npy")
+        key, shape, dtype = f_.split("-*-")
+        shape = tuple([int(s) for s in shape.split("x")])
+
+        path = os.path.join(root, f)
+
+        labels[key] = np.memmap(path, mode="c", shape=shape, dtype=dtype)
+
+    return labels
+
+
+def clean_keys(labels):
+    '''Removes all loader inforamtion from the keys.
+
+    Parameters
+    ----------
+    labels : dict(str, numpy.memmap)
+        Labels contain all load-easy dataset relevant data. 
+    
+    Returns
+    -------
+    labels : dict(str, numpy.memmap)
+        The original labels, with keys without the ``:loader`` part.
+    '''
+
+    for k_ in list(labels.keys()):
+        k, l = loader_from_key(k_)
+        if l is not None:
+            k = k + '_'
+            labels[k] = labels[k_]
+            del labels[k_]
+        else:
+            labels[k] = labels[k_]
+
+    return labels
+
+
+def loader_from_key(key):
+    '''Returns the name, loader pair given a key.'''
+
+    if ':' in key:
+        return key.split(':')
+    return key, None

--- a/edflow/data/believers/meta_loaders.py
+++ b/edflow/data/believers/meta_loaders.py
@@ -1,0 +1,51 @@
+import numpy as np
+from PIL import Image
+from edflow.data.util import adjust_support
+
+
+def image_loader(path, support='0->255'):
+    """
+
+    Parameters
+    ----------
+    path : str
+        Where to finde the image.
+    support : str
+        Defines the support and data type of the loaded image. Must be one of
+        - ``0->255``: The PIL default. Datatype is ``np.uint8`` and all values
+          are integers between 0 and 255.
+        - ``0->1``: Datatype is ``np.float32`` and all values
+          are floats between 0 and 1.
+        - ``-1->1``: Datatype is ``np.float32`` and all values
+          are floats between -1 and 1.
+
+    Returns
+    -------
+    im : np.array
+        An image loaded using :class:`PIL.Image` and adjusted to the range as
+        specified.
+    """
+
+    im = np.array(Image.open(path))
+
+    if support == '0->255':
+        return im
+    else:
+        return adjust_support(im, support, '0->255')
+
+
+def numpy_loader(path):
+    """
+
+    Parameters
+    ----------
+    path : str
+        Where to finde the array.
+
+    Returns
+    -------
+    arr : np.array
+        An array loaded using :class:`np.load`
+    """
+
+    return np.load(path)

--- a/edflow/data/believers/meta_loaders.py
+++ b/edflow/data/believers/meta_loaders.py
@@ -12,12 +12,12 @@ def image_loader(path, support="0->255"):
         Where to finde the image.
     support : str
         Defines the support and data type of the loaded image. Must be one of
-        - ``0->255``: The PIL default. Datatype is ``np.uint8`` and all values
-          are integers between 0 and 255.
-        - ``0->1``: Datatype is ``np.float32`` and all values
-          are floats between 0 and 1.
-        - ``-1->1``: Datatype is ``np.float32`` and all values
-          are floats between -1 and 1.
+            - ``0->255``: The PIL default. Datatype is ``np.uint8`` and all values
+              are integers between 0 and 255.
+            - ``0->1``: Datatype is ``np.float32`` and all values
+              are floats between 0 and 1.
+            - ``-1->1``: Datatype is ``np.float32`` and all values
+              are floats between -1 and 1.
 
     Returns
     -------

--- a/edflow/data/believers/meta_loaders.py
+++ b/edflow/data/believers/meta_loaders.py
@@ -3,7 +3,7 @@ from PIL import Image
 from edflow.data.util import adjust_support
 
 
-def image_loader(path, support='0->255'):
+def image_loader(path, support="0->255"):
     """
 
     Parameters
@@ -28,10 +28,10 @@ def image_loader(path, support='0->255'):
 
     im = np.array(Image.open(path))
 
-    if support == '0->255':
+    if support == "0->255":
         return im
     else:
-        return adjust_support(im, support, '0->255')
+        return adjust_support(im, support, "0->255")
 
 
 def numpy_loader(path):

--- a/edflow/nn/tf_nn.py
+++ b/edflow/nn/tf_nn.py
@@ -1041,7 +1041,12 @@ def probs_to_mu_L(
             ax[1, b].set_axis_off()
 
     """
-    bn, h, w, nk = (
+    (
+        bn,
+        h,
+        w,
+        nk,
+    ) = (
         probs.get_shape().as_list()
     )  # todo instead of calulating sequrity measure from amplitude one could alternativly calculate it by letting the network predict a extra paremeter also one could do
     y_t = tf.tile(tf.reshape(tf.linspace(-1.0, 1.0, h), [h, 1]), [1, w])

--- a/edflow/util.py
+++ b/edflow/util.py
@@ -16,6 +16,11 @@ except ImportError:
     __COULD_HAVE_IPYTHON__ = False
 
 
+def get_obj_from_str(string):
+    module, cls = string.rsplit(".", 1)
+    return getattr(importlib.import_module(module, package=None), cls)
+
+
 def linear_var(step, start, end, start_value, end_value, clip_min=0.0, clip_max=1.0):
     r"""
     Linear from :math:`(a, \alpha)` to :math:`(b, \beta)`, i.e.

--- a/examples/mnist_tf/iterators.py
+++ b/examples/mnist_tf/iterators.py
@@ -107,9 +107,7 @@ class Evaluator(TFBaseEvaluator):
     def __init__(self, *args, **kwargs):
         kwargs[
             "num_epochs"
-        ] = (
-            1000
-        )  # this will keep the evaluator running forever # TODO make this much nicer
+        ] = 1000  # this will keep the evaluator running forever # TODO make this much nicer
         super(Evaluator, self).__init__(*args, **kwargs)
 
         # input_names={"key_from_metric" : "key from data set"}

--- a/examples/multistage_trainer/iterators.py
+++ b/examples/multistage_trainer/iterators.py
@@ -107,9 +107,7 @@ class Evaluator(TFBaseEvaluator):
     def __init__(self, *args, **kwargs):
         kwargs[
             "num_epochs"
-        ] = (
-            1000
-        )  # this will keep the evaluator running forever # TODO make this much nicer
+        ] = 1000  # this will keep the evaluator running forever # TODO make this much nicer
         super(Evaluator, self).__init__(*args, **kwargs)
 
         # input_names={"key_from_metric" : "key from data set"}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 # allows to get version via python setup.py --version
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 # allows to get version via python setup.py --version
-__version__ = "0.3.0"
+__version__ = "0.2.1"
 
 
 setup(

--- a/tests/test_data/test_believers/test_meta.py
+++ b/tests/test_data/test_believers/test_meta.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+import os
+
+from edflow.data.believers.meta import MetaDataset
+
+
+def _setup(root, N=100):
+    from PIL import Image
+
+    root = os.path.join(root, "test_data_")
+    os.makedirs(os.path.join(root, "images"), exist_ok=True)
+
+    paths = np.array([os.path.join(root, "images", f"{i:0>3d}.png") for i in range(N)])
+
+    mmap_path = os.path.join(root, f"image:image-*-{N}-*-{paths.dtype}.npy")
+    mmap = np.memmap(mmap_path, dtype=paths.dtype, mode="w+", shape=(N,))
+    mmap[:] = paths
+
+    data = np.arange(N)
+    mmap_path = os.path.join(root, f"attr1-*-{N}-*-{data.dtype}.npy")
+    mmap = np.memmap(mmap_path, dtype=data.dtype, mode="w+", shape=(N,))
+    mmap[:] = data
+
+    data = np.zeros(shape=(N, 2))
+    mmap_path = os.path.join(root, f"attr2-*-{N}x2-*-{data.dtype}.npy")
+    mmap = np.memmap(mmap_path, dtype=data.dtype, mode="w+", shape=(N, 2))
+    mmap[:] = data
+
+    data = np.ones(shape=(N, 17, 2))
+    mmap_path = os.path.join(root, f"keypoints-*-{N}x17x2-*-{data.dtype}.npy")
+    mmap = np.memmap(mmap_path, dtype=data.dtype, mode="w+", shape=(N, 17, 2))
+    mmap[:] = data
+
+    for p in paths:
+        image = (255 * np.ones((64, 64, 3))).astype(np.uint8)
+        im = Image.fromarray(image)
+        im.save(p)
+
+    with open(os.path.join(root, "meta.yaml"), "w+") as mfile:
+        mfile.write(
+            """
+description: |
+    # Test Dataset
+
+    This is a dataset which loads images.
+    All paths to the images are in the label `image`.
+
+    ## Content
+    image: images
+
+loader_kwargs:
+    image:
+        support: "-1->1"
+        """
+        )
+
+    return root
+
+
+def _teardown(test_data_root):
+    if test_data_root == ".":
+        raise ValueError("Are you sure you want to delete this directory?")
+
+    os.system(f"rm -rf {test_data_root}")
+
+
+def test_sequence_dset_vanilla():
+    N = 100
+    try:
+        root = _setup(".", N)
+
+        M = MetaDataset(root)
+
+        assert len(M) == N
+
+        for k in ["attr1", "attr2", "image_", "keypoints"]:
+            assert k in M.labels
+            assert len(M.labels[k]) == N
+
+        d = M[0]
+        ref = {
+            "image": np.ones(shape=(64, 64, 3)),
+            "image_": os.path.join(root, "images", "000.png"),
+            "attr1": 0,
+            "attr2": np.zeros((2)),
+            "keypoints": np.ones((17, 2)),
+            "index_": 0,
+        }
+
+        for k in d:
+            assert np.all(d[k] == ref[k])
+
+        assert hasattr(M, "meta")
+
+    finally:
+        _teardown(root)


### PR DESCRIPTION
The Meta Dataset allows for easy loading of data! See the documentation for more info.

Features include:
- Standardized Loading routines for labels
- Standardized Loading routines for get_example calls via predefined functions applied to labels as defined in the datasets `meta.yaml` file or even easier via the label array's name
- Custom label to loaded thing routines are also possible, by referencing custom functions in the `meta.yaml`
- It has a nice `show` method, which probably should be part of the `DatasetMixin` class, but for now it is here. Try it in a jupyter notebook and be amazed.

Things, that should be done in the near future:
- Port the `EvalDatafolder` and the whole eval pipeline to this new dataset class (This should be relatively easy, as large parts of this class are derived from the `EvalDatafolder`)
- Once the eval pipeline is ported, package the data writing routines, such that we can easily reuse them to export arbitrary datasets.
- Write a test for the `MetaDataset`, which uses a custom function as loader