### PR TITLE
Late Loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added Late Loading! You can now return functions in your examples, which will only be evaluated at the end of you data processing pipeline, allowing you to stack many filter operations on top of each other.
 - Added MetaView Dataset, which allows to store views on a base dataset without the need to recalculate the labels everytime.
 - `TFBaseEvaluator` now parses config file for `fcond` flag to filter checkpoints, e.g.`edflow -e xxx --fcond "lambda c: any([str(n) in c for n in [240000, 320000]])"` will only evaluate checkpoint 240k and 320k
 - Added MetaDataset for easy Dataloading

--- a/edflow/data/believers/meta.py
+++ b/edflow/data/believers/meta.py
@@ -150,6 +150,9 @@ class MetaDataset(DatasetMixin):
     def show(self):
         repr_str = self.__repr__()
 
+        expand_ = self.expand
+        self.expand = True
+
         if (
             __COULD_HAVE_IPYTHON__
             and hasattr(get_ipython(), "config")
@@ -160,6 +163,8 @@ class MetaDataset(DatasetMixin):
         else:
             repr_str += f"\n\n# Example 0\n{pp2mkdtable(self.__getitem__(0), True)}"
             print(repr_str)
+
+        self.expand = expand_
 
 
 def setup_loaders(labels, meta_dict):

--- a/edflow/data/believers/meta_loaders.py
+++ b/edflow/data/believers/meta_loaders.py
@@ -30,20 +30,23 @@ def image_loader(path, support="0->255", resize_to=None):
         specified.
     """
 
-    im = Image.open(path)
+    def loader(support=support, resize_to=resize_to):
+        im = Image.open(path)
 
-    if resize_to is not None:
-        if isinstance(resize_to, int):
-            resize_to = [resize_to] * 2
+        if resize_to is not None:
+            if isinstance(resize_to, int):
+                resize_to = [resize_to] * 2
 
-        im = im.resize(resize_to)
+            im = im.resize(resize_to)
 
-    im = np.array(im)
+        im = np.array(im)
 
-    if support == "0->255":
-        return im
-    else:
-        return adjust_support(im, support, "0->255")
+        if support == "0->255":
+            return im
+        else:
+            return adjust_support(im, support, "0->255")
+
+    return loader
 
 
 def numpy_loader(path):
@@ -60,4 +63,7 @@ def numpy_loader(path):
         An array loaded using :class:`np.load`
     """
 
-    return np.load(path)
+    def loader():
+        return np.load(path)
+
+    return loader

--- a/edflow/data/dataset_mixin.py
+++ b/edflow/data/dataset_mixin.py
@@ -187,7 +187,6 @@ class DatasetMixin(DatasetMixin_):
     def _expander(self, val):
         if callable(val):
             val = val()
-        print(val)
         return val
 
     def __len__(self):

--- a/edflow/data/dataset_mixin.py
+++ b/edflow/data/dataset_mixin.py
@@ -1,5 +1,6 @@
 from chainer.dataset import DatasetMixin as DatasetMixin_
 import numpy as np
+from edflow.util import walk
 
 
 class DatasetMixin(DatasetMixin_):
@@ -161,12 +162,24 @@ class DatasetMixin(DatasetMixin_):
             ret_dict["index_"] = i
             self._maybe_append_labels(ret_dict, i)
 
+        self._maybe_expand(ret_dict)
+
         return ret_dict
 
     def _maybe_append_labels(self, datum, index):
         if self.append_labels:
             labels = {k: v[index] for k, v in self.labels.items()}
             datum.update(labels)
+
+    def _maybe_expand(self, nested_object):
+        if self.expand:
+            walk(nested_object, self._expander, inplace=True)
+
+    def _expander(self, val):
+        if callable(val):
+            val = val()
+        print(val)
+        return val
 
     def __len__(self):
         """Add default behaviour for datasets defining an attribute
@@ -276,6 +289,16 @@ class DatasetMixin(DatasetMixin_):
     @append_labels.setter
     def append_labels(self, value):
         self._append_labels = value
+
+    @property
+    def expand(self):
+        if not hasattr(self, "_expand"):
+            self._expand = False
+        return self._expand
+
+    @expand.setter
+    def expand(self, value):
+        self._expand = value
 
 
 # We need this here to avoid circular imports

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -96,6 +96,7 @@ def _train(config, root, checkpoint=None, retrain=False):
     # fork early to avoid taking all the crap into forked processes
     logger.info("Instantiating dataset.")
     dataset = implementations["dataset"](config=config)
+    dataset.expand = True
     logger.info("Number of training samples: {}".format(len(dataset)))
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))
     n_prefetch = config.get("n_prefetch", 1)
@@ -171,6 +172,7 @@ def _test(config, root, checkpoint=None, nogpu=False, bar_position=0):
     )
 
     dataset = implementations["dataset"](config=config)
+    dataset.expand = True
     logger.info("Number of testing samples: {}".format(len(dataset)))
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))
     n_prefetch = config.get("n_prefetch", 1)

--- a/tests/test_data/test_believers/test_meta.py
+++ b/tests/test_data/test_believers/test_meta.py
@@ -74,6 +74,7 @@ def test_meta_dset():
         root = _setup(".", N)
 
         M = MetaDataset(root)
+        M.expand = True
         M.show()
 
         assert len(M) == N

--- a/tests/test_data/test_believers/test_meta_view.py
+++ b/tests/test_data/test_believers/test_meta_view.py
@@ -125,6 +125,7 @@ def test_meta_view_dset():
         super_root, base_root, view_root = _setup(".", N, V)
 
         M = MetaViewDataset(view_root)
+        M.expand = True
         M.append_labels = False
         M.show()
 

--- a/tests/test_data/test_datasetmixin.py
+++ b/tests/test_data/test_datasetmixin.py
@@ -126,6 +126,36 @@ def test_dset_mxin_ops():
     D4[23]
 
 
+def test_dset_lateloading():
+    """Basically test the ConcatenatedDataset"""
+
+    class MyDset(DatasetMixin):
+        def __init__(self, N):
+            self.len = N
+
+        def get_example(self, idx):
+            def fn():
+                return idx
+
+            return {"val": fn}
+
+        def __len__(self):
+            return self.len
+
+    D = MyDset(10)
+
+    d1 = D[0]
+
+    assert callable(d1["val"])
+
+    D.expand = True
+
+    d2 = D[0]
+
+    assert d2["val"] == 0
+    assert d2["val"] == d1["val"]()
+
+
 if __name__ == "__main__":
     test_dset_mxin()
     test_dset_mxin_ops()

--- a/tests/test_edflow.py
+++ b/tests/test_edflow.py
@@ -154,7 +154,6 @@ class Test_eval(object):
         import shutil
 
         shutil.copytree(os.path.split(__file__)[0], os.path.join(tmpdir, "tests"))
-        shutil.copytree(source, destination)
         command = [
             "edflow",
             "-e",


### PR DESCRIPTION
Usually it makes sense to implement loading routines very early in a data pipeline. But this can make it very dangerous to stack multiple pipeline elements on top of each other, as filtering out intermediate views will not results in less loading operations, but only hides them.

Enter the late loading capabilities of edflow: Instead of implementing a `get_example` method, which e.g. returns a dict of image, we can now implement a method, which returns a function used for loading the image of a certain example. Setting the flag `dataset.expand = True` will then evaluate all returned functions in the dict returned by the dataset. This flag is automatically set by `edflow`, right before passing the dataset to `make_batches`.