### PR TITLE
:memo: Alter fix for mocking chainer bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,11 +60,15 @@ def run_apidoc(app):
     better_apidoc.main(
         [
             "better-apidoc",
+            "-a",
+            "-M",
             "-t",
             os.path.join(".", "templates"),
             "--force",
             "--no-toc",
             "--separate",
+            "--ext-autodoc",
+            "--ext-coverage",
             "-o",
             os.path.join(".", "source", "source_files/"),
             os.path.join("..", "edflow/"),

--- a/edflow/data/dataset_mixin.py
+++ b/edflow/data/dataset_mixin.py
@@ -2,6 +2,10 @@ from chainer.dataset import DatasetMixin as DatasetMixin_
 import numpy as np
 from edflow.util import walk, update
 
+# handle bug with mocked chainer.dataset.DatasetMixin import
+if hasattr(DatasetMixin_, "_mock_name"):
+    DatasetMixin_ = object
+
 
 class DatasetMixin(DatasetMixin_):
     """Our fork of the `chainer

--- a/edflow/data/util/util_dsets.py
+++ b/edflow/data/util/util_dsets.py
@@ -5,13 +5,6 @@ from edflow.util import retrieve
 from edflow.main import get_obj_from_str
 
 
-# handle bug with mocked chainer.dataset.DatasetMixin import
-if hasattr(DatasetMixin, "_mock_name"):
-
-    class DatasetMixin(object):
-        pass
-
-
 def JoinedDataset(dataset, key, n_joins):
     """Concat n_joins random samples based on the condition that
     example_i[key] == example_j[key] for all i,j. Key must be in labels of


### PR DESCRIPTION
Now DatasetMixin is inherited from object instead of the original
chainer class. This (hopefully) fixes all missing classes and meta-class
bugs that resulted from mocking chainer.