### PR TITLE
Adds colored logging output using logger.copyline

### DIFF
--- a/edflow/custom_logging.py
+++ b/edflow/custom_logging.py
@@ -423,14 +423,13 @@ class log(object):
         logger = logging.getLogger(name)
         logger.setLevel(level)
 
-        logger.copyline = lambda msg: logger.log(22, msg)
+        logger.colored_info = lambda msg: logger.log(22, msg)
 
         if not len(logger.handlers) > 0:
             ch = TqdmHandler()
             fh = logging.FileHandler(filename=os.path.join(out_dir, "log.txt"))
 
             fmt_string = "[%(levelname)s] [%(name)s]: %(message)s"
-            formatter = logging.Formatter(fmt_string)
             fh.setFormatter(CopyLineFormatter(False))
             ch.setFormatter(CopyLineFormatter(True))
 

--- a/edflow/custom_logging.py
+++ b/edflow/custom_logging.py
@@ -425,11 +425,7 @@ class log(object):
 
         def _colored_log(level, msg, *args, color=None, **kwargs):
             extra = kwargs.get("extra", {})
-            if color is not None:
-                extra["color"] = color
-            else:
-                if "color" not in extra:
-                    extra["color"] = ""
+            extra["color"] = color
 
             kwargs["extra"] = extra
             logger.log_orig(level, msg, *args, **kwargs)
@@ -497,16 +493,21 @@ class ColorLineFormatter(logging.Formatter):
             color_end = ""
         else:
             color = record.color
-            color_end = COLOR_SEQ_END
+            if color is None:
+                color = ""
+                color_end = ""
+            else:
+                color_end = COLOR_SEQ_END
 
-        if color in VALID_COLORS:
-            color = VALID_COLORS[color]
-        else:
-            raise ValueError(
-                f"color must be one of "
-                f"`{list(VALID_COLORS.keys())}`, but is "
-                f"`{record.color}`."
-            )
+        if color != "":
+            if color in VALID_COLORS:
+                color = VALID_COLORS[color]
+            else:
+                raise ValueError(
+                    f"color must be one of "
+                    f"`{list(VALID_COLORS.keys())}`, but is "
+                    f"`{color}`."
+                )
 
         content = {
             "color": color,

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -25,6 +25,9 @@ def test_color_info():
         logger.info("msg", color="white")
         logger.info("msg", color="black")
 
+        logger.info("nocol")
+        logger.debug("nocol")
+
         logger.info("test", extra={"color": "red"})
         logger.debug("test", extra={"color": "green"})
         logger.critical("test", extra={"color": "yellow"})

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -1,0 +1,40 @@
+"""
+Tests are only done for the added color_info method, as the rest of the
+logging is vanilla python logging.
+"""
+
+import pytest
+from edflow.custom_logging import log
+import os
+import shutil
+import logging
+
+
+def test_color_info():
+
+    try:
+        os.makedirs("color_logs")
+        logger = log._create_logger("test_logger", "./color_logs", logging.DEBUG)
+
+        logger.info("msg", color=1)
+        logger.info("msg", color="green")
+        logger.info("msg", color="y")
+        logger.debug("msg", color="c")
+        logger.error("msg", color="m")
+        logger.critical("msg", color="blue")
+        logger.info("msg", color="white")
+        logger.info("msg", color="black")
+
+        logger.info("test", extra={"color": "red"})
+        logger.debug("test", extra={"color": "green"})
+        logger.critical("test", extra={"color": "yellow"})
+
+        with pytest.raises(ValueError):
+            logger.info("msg", color="wrong")
+
+    finally:
+        shutil.rmtree("color_logs")
+
+
+if __name__ == "__main__":
+    test_color_info()


### PR DESCRIPTION
This functionality is supposed to be used for outputs containing code
snippets that can be copied like edeval commands. The color makes it so
that these lines do not get lost and improve the workflow speed.