### PR TITLE
Sequence base step

### DIFF
--- a/edflow/data/believers/sequence.py
+++ b/edflow/data/believers/sequence.py
@@ -367,7 +367,7 @@ def getSeqDataset(config):
         config[ks]["length"],
         config[ks]["step"],
         fid_key=config[ks]["fid_key"],
-        base_step=config[ks].get(base_step, 1),
+        base_step=config[ks].get("base_step", 1),
     )
 
     return S

--- a/edflow/data/believers/sequence.py
+++ b/edflow/data/believers/sequence.py
@@ -95,12 +95,12 @@ def get_sequence_view(frame_ids, length, step=1, strategy="raise"):
                 "{}".format(strategy)
             )
 
-    top_indeces = np.where(frame_ids >= (length * step - 1))[0]
+    top_indices = np.where(frame_ids >= (length * step - 1))[0]
 
     base_indices = []
     for i in range(length * step):
-        indeces = top_indeces - i
-        base_indices += [indeces]
+        indices = top_indices - i
+        base_indices += [indices]
 
     base_indices = np.array(base_indices).transpose(1, 0)[:, ::-1]
     base_indices = base_indices[:, ::step]
@@ -223,14 +223,14 @@ class SequenceDataset(DatasetMixin):
                     "{}".format(strategy)
                 )
 
-        top_indeces = np.where(np.array(frame_ids) >= (length * step - 1))[0]
+        top_indices = np.where(np.array(frame_ids) >= (length * step - 1))[0]
 
         all_subdatasets = []
         base_indices = []
         for i in range(length * step):
-            indeces = top_indeces - i
-            base_indices += [indeces]
-            subdset = SubDataset(dataset, indeces)
+            indices = top_indices - i
+            base_indices += [indices]
+            subdset = SubDataset(dataset, indices)
             all_subdatasets += [subdset]
 
         all_subdatasets = all_subdatasets[::-1]

--- a/edflow/data/believers/sequence.py
+++ b/edflow/data/believers/sequence.py
@@ -5,7 +5,7 @@ from edflow.util import get_obj_from_str
 import numpy as np
 
 
-def get_sequence_view(frame_ids, length, step=1, strategy="raise"):
+def get_sequence_view(frame_ids, length, step=1, strategy="raise", base_step=1):
     """Generates a view on some base dataset given its sequence indices
     :attr:`seq_indices`.
 
@@ -23,6 +23,8 @@ def get_sequence_view(frame_ids, length, step=1, strategy="raise"):
         - ``raise``: Raise a ``ValueError``
         - ``remove``: remove the sequence
         - ``reset``: remove the sequence
+    base_step : int
+        Step between base frames of returned sequences. Must be `>=1`.
 
     This view will have `len(dataset) - length * step` entries and shape
     `[len(dataset) - length * step, lenght]`.
@@ -95,7 +97,12 @@ def get_sequence_view(frame_ids, length, step=1, strategy="raise"):
                 "{}".format(strategy)
             )
 
-    top_indices = np.where(frame_ids >= (length * step - 1))[0]
+    top_indices = np.where(
+        np.logical_and(
+            frame_ids >= (length * step - 1),
+            (frame_ids - (length * step - 1)) % base_step == 0,
+        )
+    )[0]
 
     base_indices = []
     for i in range(length * step):
@@ -124,7 +131,9 @@ class SequenceDataset(DatasetMixin):
     the example from the sequentialized dataset.
     """
 
-    def __init__(self, dataset, length, step=1, fid_key="fid", strategy="raise"):
+    def __init__(
+        self, dataset, length, step=1, fid_key="fid", strategy="raise", base_step=1
+    ):
         """
         Parameters
         ----------
@@ -142,6 +151,8 @@ class SequenceDataset(DatasetMixin):
             - ``raise``: Raise a ``ValueError``
             - ``remove``: remove the sequence
             - ``reset``: remove the sequence
+        base_step : int
+            Step between base frames of returned sequences. Must be `>=1`.
 
         This dataset will have `len(dataset) - length * step` examples.
         """
@@ -223,7 +234,12 @@ class SequenceDataset(DatasetMixin):
                     "{}".format(strategy)
                 )
 
-        top_indices = np.where(np.array(frame_ids) >= (length * step - 1))[0]
+        top_indices = np.where(
+            np.logical_and(
+                frame_ids >= (length * step - 1),
+                (frame_ids - (length * step - 1)) % base_step == 0,
+            )
+        )[0]
 
         all_subdatasets = []
         base_indices = []
@@ -323,6 +339,7 @@ def getSeqDataset(config):
                 length: 3
                 step: 1
                 fid_key: fid
+                base_step: 1
 
     ``getSeqDataSet`` will import the base ``dataset`` and pass it to
     :class:`SequenceDataset` together with ``length`` and ``step`` to
@@ -350,6 +367,7 @@ def getSeqDataset(config):
         config[ks]["length"],
         config[ks]["step"],
         fid_key=config[ks]["fid_key"],
+        base_step=config[ks].get(base_step, 1),
     )
 
     return S

--- a/edflow/data/util/cached_dset.py
+++ b/edflow/data/util/cached_dset.py
@@ -46,8 +46,8 @@ def pickle_and_queue(
     ----------
     dataset_factory : chainer.DatasetMixin
         A dataset factory, with methods described in :class:`CachedDataset`.
-    indeces : list
-        List of indeces, used to retrieve samples from dataset.
+    indices : list
+        List of indices, used to retrieve samples from dataset.
     queue : mp.Queue
         Queue to put the samples in.
     naming_template : str
@@ -255,7 +255,7 @@ class CachedDataset(DatasetMixin):
 
     def cache_dataset(self):
         """Checks if a dataset is stored. If not iterates over all possible
-        indeces and stores the examples in a file, as well as the labels."""
+        indices and stores the examples in a file, as well as the labels."""
 
         if not os.path.isfile(self.store_path) or self.force_cache:
             print("Caching {}".format(self.store_path))
@@ -264,22 +264,22 @@ class CachedDataset(DatasetMixin):
             outqueue = manager.get_outqueue()
 
             N_examples = len(self.base_dataset)
-            indeces = np.arange(N_examples)
+            indices = np.arange(N_examples)
             if self.keep_existing and os.path.isfile(self.store_path):
                 with ZipFile(self.store_path, "r") as zip_f:
                     zipfilenames = zip_f.namelist()
                 zipfilenames = set(zipfilenames)
-                indeces = [
+                indices = [
                     i
-                    for i in indeces
+                    for i in indices
                     if not self.naming_template.format(i) in zipfilenames
                 ]
-                print("Keeping {} cached examples.".format(N_examples - len(indeces)))
-                N_examples = len(indeces)
+                print("Keeping {} cached examples.".format(N_examples - len(indices)))
+                N_examples = len(indices)
             print("Caching {} examples.".format(N_examples))
             index_chunks = [
-                indeces[i : i + self.chunk_size]
-                for i in range(0, len(indeces), self.chunk_size)
+                indices[i : i + self.chunk_size]
+                for i in range(0, len(indices), self.chunk_size)
             ]
             for chunk in index_chunks:
                 inqueue.put(chunk)


### PR DESCRIPTION
Add a base_step argument to the SequenceDataset.
The base fids have to be divisible by the base_step.
This allows a smaller sequence dataset because the sequences don't necessarily start at every frame in the dataset.
For example, with base_step of 10, the sequences start at frame 0, 10, 20, ... instead of 0, 1, 2, 3, ...
This makes the dataset effectively smaller and samples the examples equally within the possible sequences.