### PR TITLE
restore batch step and epoch step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Epoch and Batch step are restored.
 - Added option to save checkpoint zero with `--ckpt_zero True`.
 - Added support for `project` and `entity` in `integrations/wandb`.
 - Added support for `eval_functor` in test mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added option to save checkpoint zero with `--ckpt_zero True`.
+- Added support for `project` and `entity` in `integrations/wandb`.
 - Added support for `eval_functor` in test mode.
 - use `-p <rundir/configs/config.yaml>` as shortcut for `-b <rundir/configs/config.yaml> -p <rundir>`
 - Log tmux target containing current run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Debug options: `debug/disable_integrations=True`, `debug/max_examples=5 batches`.
 - Epoch and Batch step are restored.
 - Added option to save checkpoint zero with `--ckpt_zero True`.
 - Added support for `project` and `entity` in `integrations/wandb`.

--- a/edflow/hooks/checkpoint_hooks/lambda_checkpoint_hook.py
+++ b/edflow/hooks/checkpoint_hooks/lambda_checkpoint_hook.py
@@ -16,6 +16,7 @@ class LambdaCheckpointHook(Hook):
         save,
         restore,
         interval=None,
+        ckpt_zero=False,
         modelname="model",
     ):
         """
@@ -29,10 +30,26 @@ class LambdaCheckpointHook(Hook):
         self._save = save
         self._restore = restore
         self.interval = interval
+        self.ckpt_zero = ckpt_zero
 
         os.makedirs(root_path, exist_ok=True)
         self.savename = os.path.join(root_path, "{}-{{}}.ckpt".format(modelname))
         self._active = False
+
+    def before_epoch(self, epoch):
+        """
+
+        Parameters
+        ----------
+        epoch :
+
+
+        Returns
+        -------
+
+        """
+        if self.ckpt_zero and self.global_step_getter() == 0:
+            self.save(force_active=True)
 
     def after_epoch(self, epoch):
         """
@@ -86,9 +103,9 @@ class LambdaCheckpointHook(Hook):
         """
         self.save()
 
-    def save(self):
+    def save(self, force_active=False):
         """ """
-        if self._active:
+        if self._active or force_active:
             savename = self.savename.format(self.global_step_getter())
             self._save(savename)
             self.logger.info("Saved model to {}".format(savename))

--- a/edflow/iterators/model_iterator.py
+++ b/edflow/iterators/model_iterator.py
@@ -253,6 +253,9 @@ class PyHookedModelIterator(object):
                         break
                 self.run_hooks(epoch_step, before=False, epoch_hooks=True)
 
+            if self.get_global_step() >= self.config.get("num_steps", float("inf")):
+                break
+
     def run(self, fetches, feed_dict):
         """Runs all fetch ops and stores the results.
 

--- a/edflow/iterators/model_iterator.py
+++ b/edflow/iterators/model_iterator.py
@@ -163,13 +163,21 @@ class PyHookedModelIterator(object):
                 batches_per_epoch, self.config["max_batches_per_epoch"]
             )
         num_epochs = 1 if epoch_hooks_only else self.num_epochs
-        start_epoch = 0 if epoch_hooks_only else (
-            self.get_global_step() // batches_per_epoch)
-        start_step = 0 if epoch_hooks_only else (
-            self.get_global_step() % batches_per_epoch)
+        start_epoch = (
+            0 if epoch_hooks_only else (self.get_global_step() // batches_per_epoch)
+        )
+        start_step = (
+            0 if epoch_hooks_only else (self.get_global_step() % batches_per_epoch)
+        )
         for epoch_step in trange(
-            start_epoch, num_epochs, initial=start_epoch, total=num_epochs,
-            desc=desc_epoch, position=pos, dynamic_ncols=True, leave=False,
+            start_epoch,
+            num_epochs,
+            initial=start_epoch,
+            total=num_epochs,
+            desc=desc_epoch,
+            position=pos,
+            dynamic_ncols=True,
+            leave=False,
         ):
             self._epoch_step = epoch_step
 
@@ -178,9 +186,14 @@ class PyHookedModelIterator(object):
             self.run_hooks(epoch_step, before=True)
 
             for batch_step in trange(
-                start_step, batches_per_epoch, initial=start_step,
-                total=batches_per_epoch, desc=desc_batch, position=pos + 1,
-                dynamic_ncols=True, leave=False,
+                start_step,
+                batches_per_epoch,
+                initial=start_step,
+                total=batches_per_epoch,
+                desc=desc_batch,
+                position=pos + 1,
+                dynamic_ncols=True,
+                leave=False,
             ):
                 self._batch_step = batch_step
 

--- a/edflow/iterators/template_iterator.py
+++ b/edflow/iterators/template_iterator.py
@@ -76,15 +76,17 @@ class TemplateIterator(PyHookedModelIterator):
                     "/", "-"
                 )
                 wandb_project = set_default(
-                    self.config,
-                    "integrations/wandb/project",
-                    None)
+                    self.config, "integrations/wandb/project", None
+                )
                 wandb_entity = set_default(
-                    self.config,
-                    "integrations/wandb/entity",
-                    None)
-                wandb.init(name=ProjectManager.root, config=self.config,
-                           project=wandb_project, entity=wandb_entity)
+                    self.config, "integrations/wandb/entity", None
+                )
+                wandb.init(
+                    name=ProjectManager.root,
+                    config=self.config,
+                    project=wandb_project,
+                    entity=wandb_entity,
+                )
 
                 handlers = set_default(
                     self.config,

--- a/edflow/iterators/template_iterator.py
+++ b/edflow/iterators/template_iterator.py
@@ -74,7 +74,16 @@ class TemplateIterator(PyHookedModelIterator):
                 os.environ["WANDB_RUN_ID"] = ProjectManager.root.strip("/").replace(
                     "/", "-"
                 )
-                wandb.init(name=ProjectManager.root, config=self.config)
+                wandb_project = set_default(
+                    self.config,
+                    "integrations/wandb/project",
+                    None)
+                wandb_entity = set_default(
+                    self.config,
+                    "integrations/wandb/entity",
+                    None)
+                wandb.init(name=ProjectManager.root, config=self.config,
+                           project=wandb_project, entity=wandb_entity)
 
                 handlers = set_default(
                     self.config,

--- a/edflow/iterators/template_iterator.py
+++ b/edflow/iterators/template_iterator.py
@@ -29,6 +29,7 @@ class TemplateIterator(PyHookedModelIterator):
             save=self.save,
             restore=self.restore,
             interval=set_default(self.config, "ckpt_freq", None),
+            ckpt_zero=set_default(self.config, "ckpt_zero", False),
         )
         # write checkpoints after epoch or when interrupted during training
         if not self.config.get("test_mode", False):

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -31,6 +31,10 @@ def train(config, root, checkpoint=None, retrain=False, debug=False):
             integrations = retrieve(config, "integrations", default=dict())
             for k in integrations:
                 config["integrations"][k]["active"] = False
+        max_steps = retrieve(config, "debug/max_steps",
+                             default=5*2)
+        if max_steps > 0:
+            config["num_steps"] = max_steps
 
     # backwards compatibility
     if not "datasets" in config:

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -6,7 +6,7 @@ import math
 import datetime
 
 from edflow.custom_logging import log, run
-from edflow.util import get_obj_from_str
+from edflow.util import get_obj_from_str, retrieve, set_value
 
 
 def _save_config(config, prefix="config"):
@@ -24,6 +24,13 @@ def _save_config(config, prefix="config"):
 def train(config, root, checkpoint=None, retrain=False, debug=False):
     """Run training. Loads model, iterator and dataset according to config."""
     from edflow.iterators.batches import make_batches
+
+    # disable integrations in debug mode
+    if debug:
+        if retrieve(config, "debug/disable_integrations", default=True):
+            integrations = retrieve(config, "integrations", default=dict())
+            for k in integrations:
+                config["integrations"][k]["active"] = False
 
     # backwards compatibility
     if not "datasets" in config:
@@ -48,8 +55,12 @@ def train(config, root, checkpoint=None, retrain=False, debug=False):
         datasets[split].expand = True
         logger.info("{} dataset size: {}".format(split, len(datasets[split])))
         if debug:
-            logger.info("Monkey patching {} dataset __len__".format(split))
-            type(datasets[split]).__len__ = lambda self: 100
+            max_examples = retrieve(config, "debug/max_examples",
+                                    default=5*config["batch_size"])
+            if max_examples > 0:
+                logger.info("Monkey patching {} dataset __len__ to {} examples".format(
+                    split, max_examples))
+                type(datasets[split]).__len__ = lambda self: max_examples
 
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))
     n_prefetch = config.get("n_prefetch", 1)
@@ -139,8 +150,12 @@ def test(config, root, checkpoint=None, nogpu=False, bar_position=0, debug=False
         datasets[split].expand = True
         logger.info("{} dataset size: {}".format(split, len(datasets[split])))
         if debug:
-            logger.info("Monkey patching {} dataset __len__".format(split))
-            type(datasets[split]).__len__ = lambda self: 100
+            max_examples = retrieve(config, "debug/max_examples",
+                                    default=5*config["batch_size"])
+            if max_examples > 0:
+                logger.info("Monkey patching {} dataset __len__ to {} examples".format(
+                    split, max_examples))
+                type(datasets[split]).__len__ = lambda self: max_examples
 
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))
     n_prefetch = config.get("n_prefetch", 1)

--- a/edflow/main.py
+++ b/edflow/main.py
@@ -31,8 +31,7 @@ def train(config, root, checkpoint=None, retrain=False, debug=False):
             integrations = retrieve(config, "integrations", default=dict())
             for k in integrations:
                 config["integrations"][k]["active"] = False
-        max_steps = retrieve(config, "debug/max_steps",
-                             default=5*2)
+        max_steps = retrieve(config, "debug/max_steps", default=5 * 2)
         if max_steps > 0:
             config["num_steps"] = max_steps
 
@@ -59,11 +58,15 @@ def train(config, root, checkpoint=None, retrain=False, debug=False):
         datasets[split].expand = True
         logger.info("{} dataset size: {}".format(split, len(datasets[split])))
         if debug:
-            max_examples = retrieve(config, "debug/max_examples",
-                                    default=5*config["batch_size"])
+            max_examples = retrieve(
+                config, "debug/max_examples", default=5 * config["batch_size"]
+            )
             if max_examples > 0:
-                logger.info("Monkey patching {} dataset __len__ to {} examples".format(
-                    split, max_examples))
+                logger.info(
+                    "Monkey patching {} dataset __len__ to {} examples".format(
+                        split, max_examples
+                    )
+                )
                 type(datasets[split]).__len__ = lambda self: max_examples
 
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))
@@ -154,11 +157,15 @@ def test(config, root, checkpoint=None, nogpu=False, bar_position=0, debug=False
         datasets[split].expand = True
         logger.info("{} dataset size: {}".format(split, len(datasets[split])))
         if debug:
-            max_examples = retrieve(config, "debug/max_examples",
-                                    default=5*config["batch_size"])
+            max_examples = retrieve(
+                config, "debug/max_examples", default=5 * config["batch_size"]
+            )
             if max_examples > 0:
-                logger.info("Monkey patching {} dataset __len__ to {} examples".format(
-                    split, max_examples))
+                logger.info(
+                    "Monkey patching {} dataset __len__ to {} examples".format(
+                        split, max_examples
+                    )
+                )
                 type(datasets[split]).__len__ = lambda self: max_examples
 
     n_processes = config.get("n_data_processes", min(16, config["batch_size"]))

--- a/examples/template_pytorch/edflow.py
+++ b/examples/template_pytorch/edflow.py
@@ -101,7 +101,7 @@ def acc_callback(root, data_in, data_out, config):
     # labels are loaded directly into memory
     loss1 = np.mean(data_out.labels["loss"])
     loss2 = 0.0
-    for i in trange(len(data_in)):
+    for i in trange(len(data_in), leave=False):
         # data_in is the dataset that was used for evaluation
         labels = data_in[i]["class"]
         # data_out contains all the keys that were specified in the eval_op


### PR DESCRIPTION
when restoring the global step, edflow now also restores the epoch and batch progress bars. note however that this only makes sense if the batch size wasn't changed.

in addition this PR improves the progress bar display a bit. since some new version of tqdm, progress bars accumulate without setting `leave=False`. This should also be done in callbacks' progress bars. Also we only keep two lines of progress bars now, the epoch always on top and below it the current iteration loop (training or validation or callbacks' iteration).

project and entity can be specified for wandb to log into team accounts, ckpt_zero can be set to True to save the zero-th checkpoint and `debug/{disable_integrations, max_examples}` can be used to adjust behavior in debug mode.