### PR TITLE
Logging hooks: Changes from TensorboardX to tensorboard.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
     - source activate test-environment
     - conda install pytorch-cpu torchvision-cpu -c pytorch
-    - pip install tensorboardX
+    - pip install tensorboard
     - pip install -e .[test]
     script:
     - cd examples
@@ -63,7 +63,7 @@ jobs:
     - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION tensorflow=1.13.1
     - source activate test-environment
     - conda install pytorch-cpu torchvision-cpu -c pytorch
-    - pip install tensorboardX
+    - pip install tensorboard
     - pip install -e .[test]
     script:
     - python -c "import skimage"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `eval_functor` in test mode.
 - use `-p <rundir/configs/config.yaml>` as shortcut for `-b <rundir/configs/config.yaml> -p <rundir>`
 - Log tmux target containing current run.
-- Support for tensorboardX logging. Enable with `--tensorboardX_logging True`.
+- Support for tensorboard logging. Enable with `--tensorboard_logging True`.
 - Support for wandb logging. Enable with `--wandb_logging True`.
 - Support for flow visualizations in edexplore and improved index selection.
 - Git integration adds all .py and .yaml files not just tracked ones.
@@ -36,10 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CHANGELOG.md to document notable changes.
 
 ### Changed
+- Changed usage from tensorboardX to tensorboard, due to native intergration in pytorch.
 - EvalPipeline defaults to keypath/labels for finding labels.
 - A `datasets` dict is now preferred over `dataset` and `validation_dataset` (backwards compatible default: `dataset` -> `datasets/train` and `validation_dataset` -> `datasets/validation`).
 - Eval Pipeline now stores data compatible with MetaDataset specifications. Previously exported data cannot be read again using edeval after this change.
-- Changed configuration of integrations: `EDFLOWGIT` now `integrations/git`, `wandb_logging` now `integrations/wandb`, `tensorboardX_logging` now `--integrations/tensorboardX`.
+- Changed configuration of integrations: `EDFLOWGIT` now `integrations/git`, `wandb_logging` now `integrations/wandb`, `tensorboard_logging` now `--integrations/tensorboard`.
 - ProjectManager is now `edflow.run` and initialized with `edflow.run.init(...)`.
 - Saved config files use `-` instead of `:` in filename to be consistent.
 - No more `-e/--evaluation <config>` and `-t/--train <config>` options. Specify all configs under `-b/--base <config1> <config2>`. Default to evaluation mode, specify `-t/--train` for training mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Logging figures using tensorboard now possible using log_tensorboard_figures.
 - Added support for `eval_functor` in test mode.
 - use `-p <rundir/configs/config.yaml>` as shortcut for `-b <rundir/configs/config.yaml> -p <rundir>`
 - Log tmux target containing current run.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ MOCK_MODULES = [
     "torch",
     "skimage",
     "skimage.measure",
-    "tensorboardX",
+    "tensorboard",
     "streamlit",
     "wandb",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,6 @@ MOCK_MODULES = [
     "torch",
     "skimage",
     "skimage.measure",
-    "tensorboard",
     "streamlit",
     "wandb",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ MOCK_MODULES = [
     "tensorflow.python.ops",
     "tensorflow.python.framework",
     "torch",
+    "torch.utils.tensorboard",
     "skimage",
     "skimage.measure",
     "streamlit",

--- a/docs/source/git.rst
+++ b/docs/source/git.rst
@@ -26,10 +26,10 @@ Weights and biases integration can be enabled with the config parameter
 logging values and images to weights and biases. To disable image logging use
 ``--integrations/wandb/handlers '["scalars"]'``.
 
-tensorboardX
+tensorboard
 ------------
 
-TensorboardX integration can be enabled with the config parameter
-``--integrations/tensorboardX/active True``. By default, this will log the config,
-scalar logging values and images to tensorboardX. To disable image logging use
-``--integrations/tensorboardX/handlers '["scalars"]'``.
+Tensorboard integration can be enabled with the config parameter
+``--integrations/tensorboard/active True``. By default, this will log the config,
+scalar logging values and images to tensorboard. To disable image logging use
+``--integrations/tensorboard/handlers '["scalars"]'``.

--- a/edflow/hooks/logging_hooks/minimal_logging_hook.py
+++ b/edflow/hooks/logging_hooks/minimal_logging_hook.py
@@ -34,7 +34,11 @@ class LoggingHook(Hook):
         for path in self.paths:
             os.makedirs(os.path.join(self.root, path), exist_ok=True)
             self.loggers[path] = get_logger(path)
-        self.handlers = {"images": [self.log_images], "scalars": [self.log_scalars]}
+        self.handlers = {
+            "images": [self.log_images],
+            "scalars": [self.log_scalars],
+            "figures": [self.log_figures],
+        }
 
     def __call__(self, results, step, paths):
         for path in paths:
@@ -65,6 +69,18 @@ class LoggingHook(Hook):
             if not path in self.loggers:
                 self.loggers[path] = get_logger(path)
             self.loggers[path].info("{}: {}".format(name, results[name]))
+
+    def log_figures(self, results, step, path):
+        import matplotlib.pyplot as plt
+
+        for name, figure in results.items():
+            full_name = name + "_{:07}.png".format(step)
+            save_path = os.path.join(self.root, path, full_name)
+            try:
+                plt.savefig(save_path)
+            except FileNotFoundError:
+                os.makedirs(os.path.split(save_path)[0])
+                plt.savefig(save_path)
 
     def log_images(self, results, step, path):
         for name, image_batch in results.items():

--- a/edflow/hooks/logging_hooks/tensorboard_handler.py
+++ b/edflow/hooks/logging_hooks/tensorboard_handler.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorboardX
 import yaml
 from edflow.iterators.batches import batch_to_canvas
 
@@ -17,6 +16,13 @@ def log_tensorboard_images(writer, results, step, path):
         v = batch_to_canvas(v)
         v = ((v + 1) * 127.5).astype(np.uint8)
         writer.add_image(tag=k, img_tensor=v, global_step=step, dataformats="HWC")
+    writer.flush()
+
+
+def log_tensorboard_figures(writer, results, step, path):
+    results = dict((path + "/" + k, v) for k, v in results.items())
+    for k, v in results.items():
+        writer.add_figure(tag=k, figure=v, global_step=step)
     writer.flush()
 
 

--- a/edflow/hooks/pytorch_hooks.py
+++ b/edflow/hooks/pytorch_hooks.py
@@ -3,7 +3,7 @@ import sys
 
 import torch
 import numpy as np
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from edflow.hooks.hook import Hook
 from edflow.custom_logging import get_logger

--- a/edflow/iterators/template_iterator.py
+++ b/edflow/iterators/template_iterator.py
@@ -86,43 +86,53 @@ class TemplateIterator(PyHookedModelIterator):
                 if "images" in handlers:
                     self.loghook.handlers["images"].append(log_wandb_images)
 
-            default_tensorboardX_logging = {
+            default_tensorboard_logging = {
                 "active": False,
-                "handlers": ["scalars", "images"],
+                "handlers": ["scalars", "images", "figures"],
             }
-            tensorboardX_logging = set_default(
-                self.config, "integrations/tensorboardX", default_tensorboardX_logging
+            tensorboard_logging = set_default(
+                self.config, "integrations/tensorboard", default_tensorboard_logging
             )
-            if tensorboardX_logging["active"]:
-                from tensorboardX import SummaryWriter
-                from edflow.hooks.logging_hooks.tensorboardX_handler import (
+            if tensorboard_logging["active"]:
+                try:
+                    from torch.utils.tensorboard import SummaryWriter
+                except:
+                    from tensorboardX import SummaryWriter
+
+                from edflow.hooks.logging_hooks.tensorboard_handler import (
                     log_tensorboard_config,
                     log_tensorboard_scalars,
                     log_tensorboard_images,
+                    log_tensorboard_figures,
                 )
 
-                self.tensorboardX_writer = SummaryWriter(ProjectManager.root)
+                self.tensorboard_writer = SummaryWriter(ProjectManager.root)
                 log_tensorboard_config(
-                    self.tensorboardX_writer, self.config, self.get_global_step()
+                    self.tensorboard_writer, self.config, self.get_global_step()
                 )
                 handlers = set_default(
                     self.config,
-                    "integrations/tensorboardX/handlers",
-                    default_tensorboardX_logging["handlers"],
+                    "integrations/tensorboard/handlers",
+                    default_tensorboard_logging["handlers"],
                 )
                 if "scalars" in handlers:
                     self.loghook.handlers["scalars"].append(
                         lambda *args, **kwargs: log_tensorboard_scalars(
-                            self.tensorboardX_writer, *args, **kwargs
+                            self.tensorboard_writer, *args, **kwargs
                         )
                     )
                 if "images" in handlers:
                     self.loghook.handlers["images"].append(
                         lambda *args, **kwargs: log_tensorboard_images(
-                            self.tensorboardX_writer, *args, **kwargs
+                            self.tensorboard_writer, *args, **kwargs
                         )
                     )
-
+                if "figures" in handlers:
+                    self.loghook.handlers["figures"].append(
+                        lambda *args, **kwargs: log_tensorboard_figures(
+                            self.tensorboard_writer, *args, **kwargs
+                        )
+                    )
         ## epoch hooks
 
         # evaluate validation/step_ops/eval_op after each epoch

--- a/environments/edflow_pt_cu9.yaml
+++ b/environments/edflow_pt_cu9.yaml
@@ -6,9 +6,9 @@ dependencies:
   - python=3.6
   - cudatoolkit=9.0
   - cudnn=7.1.2
-  - pytorch=1.0.1
+  - pytorch=1.1.0
   - torchvision=0.2.2
   - pip:
-    - tensorboardx==1.6
+    - tensorboard
     - tensorflow-gpu==1.12.0
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_full = [  # for extra functionality
     "matplotlib",  # for plot_datum
     "flowiz",  # for visualizing flow with streamlit
     "wandb",  # for `--wandb_logging True`
-    "tensorboardX",  # for `--tensorboardX_logging True`
+    "tensorboard",  # for `--tensorboard_logging True`
 ]
 install_docs = [  # for building the documentation
     "sphinx >= 1.4",


### PR DESCRIPTION
This PR changes the current usage from tensorboardX to tensorboard.
Since [PyTorch](https://pytorch.org/docs/stable/tensorboard.html) natively supports tensorboard it would be nice to use it instead of tensorboardX.

Added Features:
Added log_tensorboard_figures functionality to add matplotlib figures to the logging mechanism.