### PR TITLE
Updated Changelog for release #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+
+## [0.3.1] - 2020-03-02
 ### Added
 - Root parameter for image and numpy loader of the meta dataset. `root` is prepended to the given paths and thus allows for smaller label arrays
 - Category loader allows to convert a given label into a more expressive category, which is specifed in the dataset's `meta.yaml`


### PR DESCRIPTION
This time a release should be triggered, as the commit message contains #minor. The release tag will be automatically created with a version number.
Possible release hashtags are #major (0.3.0 -> 1.0.0), #minor (0.3.0 -> 0.4.0), #patch (0.3.0 -> 0.3.1).