### PR TITLE
Profiling

### DIFF
--- a/edflow/hooks/logging_hooks/pt_profiling.py
+++ b/edflow/hooks/logging_hooks/pt_profiling.py
@@ -1,0 +1,59 @@
+import os
+import torch
+from datetime import datetime
+
+from edflow.hooks.hook import Hook
+from edflow.project_manager import ProjectManager as P
+from edflow.custom_logging import get_logger
+
+
+class PyProfilingHook(Hook):
+    '''Allows to profile your pytorch code!
+
+    Best of all: It allows you to create chrome traces, which can be view
+    interactively in you browser:
+
+    1. Add the hook: 
+
+    ``` python
+    class MyIterator(TemplateIterator):
+        def __init__(...):
+            ...
+            self.hooks += [ProfilingHook()]
+    ```
+
+    2. Run edflow as usual
+    3. Open Chrome and enter ``chrome://tracing``. Use the ``Load`` button to
+    open the generated trace, which can be found at ``<Project
+    root>/train/profiling/<date>.ctrace``
+
+    '''
+
+    def __init__(self, use_cuda=True, record_shapes=False, ):
+        self.logger = get_logger(self)
+
+        self.log_root = os.path.join(P.root, 'profiling')
+        os.makedirs(self.log_root, exist_ok=True)
+
+        self.profiler = torch.autograd.profiler.profile(
+            use_cuda=use_cuda,
+            record_shapes=record_shapes
+        )
+
+        self.profiler.__enter__()
+
+    def save_trace(self):
+        self.profiler.__exit__(None, None, None)
+
+        now = datetime.now()
+        time = date_time = now.strftime("%Y-%m-%dT%H-%M-%S")
+        save_path = os.path.join(self.log_root, f'{time}.ctrace')
+        self.profiler.export_chrome_trace(save_path)
+
+        self.logger.info(f'Saved profiling trace to {save_path}')
+
+    def at_exception(self, exception):
+        self.save_trace()
+
+    def after_epoch(self, epoch):
+        self.save_trace()


### PR DESCRIPTION
Introducing: The Pytorch Profiling hook! Saves a trace, that can be interactively viewed via the ``chrome://tracing`` tool. Take a look at the attached pictures.

Still on the todo list:

- [ ] Add warning that traces get huge fast! Solution: `--num_steps 20``
- [ ] Add example interpretation (?)

Image 1: Some 15 training steps. Note the validation steps every 2^n steps.
![zoom_0](https://user-images.githubusercontent.com/9572598/85345499-e8db6880-b4f2-11ea-8360-96caacbf58a8.png)
Image 2: Zoom to about one step. Left: Forward pass, middle: gradient calculation, right: gradient application.
![zoom_1](https://user-images.githubusercontent.com/9572598/85345502-ea0c9580-b4f2-11ea-9c88-44cf62e71f85.png)
Image 3: Some Conv - Batch-Norm - ReLU layers
![zoom_2](https://user-images.githubusercontent.com/9572598/85345505-eaa52c00-b4f2-11ea-915b-53b88cd6611a.png)
